### PR TITLE
Add CI workflow for tests and Docker publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,27 @@ jobs:
       - run: npm run build
       - run: npm test
 
-  docker:
-    needs: test
+  changes:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    outputs:
+      deployable: ${{ steps.filter.outputs.deployable }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            deployable:
+              - 'src/**'
+              - 'Dockerfile'
+              - 'package*.json'
+              - 'tsconfig.json'
+
+  docker:
+    needs: [test, changes]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.deployable == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI workflow that runs build + tests on all pushes to main and PRs
- On pushes to main, build and publish Docker image to `ghcr.io/windoze95/servicewow-mcp` with `latest` and commit SHA tags
- Uses GHA build cache for faster Docker builds

## Test plan
- [x] Verify tests run on this PR
- [x] Merge to main and verify Docker image is not published to GHCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)