### PR TITLE
Add unit tests, coverage gate, and project docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,37 @@
+# AI Agent Instructions
+
+## Project Context
+- This repository is a ServiceNow MCP server built with TypeScript + Node.js 22.
+- It uses Express + Streamable HTTP transport, Redis-backed token/session storage, and OAuth 2.0 per-user delegation.
+- Prioritize correctness and security over broad refactors.
+
+## Architecture Highlights
+- `src/index.ts`: process startup/shutdown wiring.
+- `src/server.ts`: Express app, MCP routes, session lifecycle.
+- `src/auth/*`: OAuth callback, encryption, token store, refresh logic.
+- `src/tools/*`: MCP tool implementations grouped by domain.
+- `src/middleware/*`: error normalization, rate limiting, session helpers.
+- `src/servicenow/*`: API client and query building.
+
+## Agent Priorities & Required Workflow
+1. Match existing code patterns before proposing new abstractions.
+2. Keep edits scoped to the user request.
+3. Include tests for behavior changes.
+4. Run validation commands before finishing.
+
+## Implementation Guardrails
+- Do not bypass identity enforcement logic in tools.
+- Do not remove or weaken input validation (`sys_id`, enums, payload sanitization).
+- Do not modify generated/runtime folders (`dist/`, `coverage/`, `node_modules/`).
+- Do not add dependencies unless necessary.
+- Never commit secrets or sample real credentials.
+
+## Validation Commands
+- Build: `npm run build`
+- Tests: `npm test`
+- Coverage (when tests change): `npm run test:coverage`
+
+## Testing Notes
+- Use Vitest with focused unit tests.
+- Mock ServiceNow, Redis, and MCP transport interactions.
+- Keep coverage thresholds passing.

--- a/.github/workflows/check-ai-instructions.yml
+++ b/.github/workflows/check-ai-instructions.yml
@@ -1,0 +1,39 @@
+name: Check AI Instructions Alignment
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'AGENTS.md'
+      - 'CLAUDE.md'
+      - '.github/copilot-instructions.md'
+      - '.github/workflows/check-ai-instructions.yml'
+  pull_request:
+    paths:
+      - 'AGENTS.md'
+      - 'CLAUDE.md'
+      - '.github/copilot-instructions.md'
+      - '.github/workflows/check-ai-instructions.yml'
+
+jobs:
+  check-alignment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Verify instruction files match
+        run: |
+          echo "Checking if CLAUDE.md and .github/copilot-instructions.md match AGENTS.md..."
+          
+          if ! diff -q AGENTS.md CLAUDE.md; then
+            echo "::error file=CLAUDE.md::CLAUDE.md does not match AGENTS.md. Please ensure all AI instruction files are identical."
+            exit 1
+          fi
+          
+          if ! diff -q AGENTS.md .github/copilot-instructions.md; then
+            echo "::error file=.github/copilot-instructions.md::.github/copilot-instructions.md does not match AGENTS.md. Please ensure all AI instruction files are identical."
+            exit 1
+          fi
+          
+          echo "✅ All instruction files are perfectly aligned."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
       - run: npm ci
       - run: npm run build
-      - run: npm test
+      - run: npm run test:coverage
 
   changes:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# AI Agent Instructions
+
+## Project Context
+- This repository is a ServiceNow MCP server built with TypeScript + Node.js 22.
+- It uses Express + Streamable HTTP transport, Redis-backed token/session storage, and OAuth 2.0 per-user delegation.
+- Prioritize correctness and security over broad refactors.
+
+## Architecture Highlights
+- `src/index.ts`: process startup/shutdown wiring.
+- `src/server.ts`: Express app, MCP routes, session lifecycle.
+- `src/auth/*`: OAuth callback, encryption, token store, refresh logic.
+- `src/tools/*`: MCP tool implementations grouped by domain.
+- `src/middleware/*`: error normalization, rate limiting, session helpers.
+- `src/servicenow/*`: API client and query building.
+
+## Agent Priorities & Required Workflow
+1. Match existing code patterns before proposing new abstractions.
+2. Keep edits scoped to the user request.
+3. Include tests for behavior changes.
+4. Run validation commands before finishing.
+
+## Implementation Guardrails
+- Do not bypass identity enforcement logic in tools.
+- Do not remove or weaken input validation (`sys_id`, enums, payload sanitization).
+- Do not modify generated/runtime folders (`dist/`, `coverage/`, `node_modules/`).
+- Do not add dependencies unless necessary.
+- Never commit secrets or sample real credentials.
+
+## Validation Commands
+- Build: `npm run build`
+- Tests: `npm test`
+- Coverage (when tests change): `npm run test:coverage`
+
+## Testing Notes
+- Use Vitest with focused unit tests.
+- Mock ServiceNow, Redis, and MCP transport interactions.
+- Keep coverage thresholds passing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,37 @@
+# AI Agent Instructions
+
+## Project Context
+- This repository is a ServiceNow MCP server built with TypeScript + Node.js 22.
+- It uses Express + Streamable HTTP transport, Redis-backed token/session storage, and OAuth 2.0 per-user delegation.
+- Prioritize correctness and security over broad refactors.
+
+## Architecture Highlights
+- `src/index.ts`: process startup/shutdown wiring.
+- `src/server.ts`: Express app, MCP routes, session lifecycle.
+- `src/auth/*`: OAuth callback, encryption, token store, refresh logic.
+- `src/tools/*`: MCP tool implementations grouped by domain.
+- `src/middleware/*`: error normalization, rate limiting, session helpers.
+- `src/servicenow/*`: API client and query building.
+
+## Agent Priorities & Required Workflow
+1. Match existing code patterns before proposing new abstractions.
+2. Keep edits scoped to the user request.
+3. Include tests for behavior changes.
+4. Run validation commands before finishing.
+
+## Implementation Guardrails
+- Do not bypass identity enforcement logic in tools.
+- Do not remove or weaken input validation (`sys_id`, enums, payload sanitization).
+- Do not modify generated/runtime folders (`dist/`, `coverage/`, `node_modules/`).
+- Do not add dependencies unless necessary.
+- Never commit secrets or sample real credentials.
+
+## Validation Commands
+- Build: `npm run build`
+- Tests: `npm test`
+- Coverage (when tests change): `npm run test:coverage`
+
+## Testing Notes
+- Use Vitest with focused unit tests.
+- Mock ServiceNow, Redis, and MCP transport interactions.
+- Keep coverage thresholds passing.

--- a/README.md
+++ b/README.md
@@ -1,138 +1,332 @@
 # ServiceNow MCP Server
 
-An MCP (Model Context Protocol) server that proxies authenticated ServiceNow REST API access through per-user OAuth 2.0 tokens. Every action runs as the authenticated user, inheriting their ACLs, roles, and audit trail.
+![Node 22+](https://img.shields.io/badge/Node-22%2B-43853d?logo=node.js&logoColor=white)
+![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178c6?logo=typescript&logoColor=white)
+![MCP](https://img.shields.io/badge/MCP-Streamable%20HTTP-6f42c1)
+![OAuth 2.0](https://img.shields.io/badge/Auth-OAuth%202.0-0a66c2)
+![CI](https://img.shields.io/badge/CI-Build%20%2B%20Coverage-success)
 
-## Architecture
+Secure, enterprise-ready MCP server for ServiceNow where every action runs as the authenticated user.
 
+No shared service accounts. No ACL bypass. Full audit-trail fidelity.
+
+---
+
+## ⚡ Why This Exists
+
+Instead of funneling every request through a shared service account, this server executes actions as the actual human user.
+
+Because it uses **per-user OAuth tokens**, ServiceNow still enforces:
+
+- each user’s ACLs and roles,
+- their approval authority,
+- and native user-level audit logging.
+
+Result: safer automation, cleaner compliance, fewer permission hacks.
+
+---
+
+## 🔥 Core Capabilities
+
+- Per-user OAuth 2.0 Authorization Code flow + refresh
+- AES-256-GCM encrypted token storage in Redis
+- Streamable HTTP MCP transport with per-session lifecycle
+- Tool-level identity protections for sensitive operations
+- Per-user rate limiting via Redis token bucket
+- Input validation + normalized error responses
+- CI-enforced build + test + coverage gate
+
+---
+
+## 🧠 Architecture
+
+```mermaid
+flowchart LR
+    Client[MCP Client] --> MCP[ServiceNow MCP Server\nExpress + MCP SDK]
+    MCP --> Redis[(Redis\nEncrypted tokens + sessions)]
+    MCP --> SN[(ServiceNow REST APIs)]
+
+    MCP --> OAuth[OAuth 2.0\nPer-user delegation]
+    SN --> ACL[ACL + Role Enforcement]
+    SN --> Audit[Native Audit Trail]
 ```
-MCP Client ──► MCP Server (Express + Streamable HTTP) ──► ServiceNow REST API
-                        │
-                        └──► Redis (encrypted token store)
-```
 
-- **Per-user OAuth 2.0**: Authorization Code Grant flow — no shared service accounts
-- **Encrypted token storage**: AES-256-GCM encrypted at rest in Redis
-- **Per-session MCP instances**: Each MCP session gets its own server + transport pair
-- **Rate limiting**: Token bucket algorithm per user via Redis
+Key modules:
 
-## Quick Start
+- `src/index.ts` — startup/shutdown wiring
+- `src/server.ts` — HTTP app + MCP routes/session lifecycle
+- `src/auth/*` — OAuth callback, encryption, token store, token refresh
+- `src/tools/*` — tool implementations by domain
+- `src/middleware/*` — rate limiting, error normalization
+- `src/servicenow/*` — API client + query helpers
+
+---
+
+## 🚀 Quick Start
 
 ### Prerequisites
 
 - Node.js 22+
-- Redis (or Docker Compose)
-- A ServiceNow instance with an OAuth Application Registry entry
+- Redis
+- ServiceNow instance with OAuth app configured
 
-### Development
+### Local Setup
 
 ```bash
-# Install dependencies
 npm install
-
-# Copy and configure environment
 cp .env.example .env
-# Edit .env with your ServiceNow instance details
-
-# Generate encryption key
 npm run generate-key
-# Add the output to your .env file
-
-# Start in development mode
+# paste generated key into TOKEN_ENCRYPTION_KEY in .env
 npm run dev
 ```
 
-### Docker Deployment
+Health check:
 
 ```bash
-# One-shot setup (Linux VM)
-chmod +x setup.sh
-./setup.sh
+curl -s http://localhost:8080/health
+```
 
-# Or manually:
+### Docker
+
+```bash
 docker compose up -d --build
 ```
 
-## ServiceNow Setup
+One-shot Linux VM setup is available via `setup.sh`.
 
-### OAuth Application
+---
 
-1. Navigate to **System OAuth > Application Registry** in ServiceNow
-2. Create: **"Create an OAuth API endpoint for external clients"**
-3. Configure:
-   - **Redirect URL**: `https://<your-host>:8080/oauth/callback`
-   - Note the **Client ID** and **Client Secret**
-4. Add these to your `.env` file
+## 🛠 ServiceNow Setup
 
-### User Role Requirements
+1. Go to **System OAuth > Application Registry**
+2. Create **OAuth API endpoint for external clients**
+3. Set redirect URI (example): `https://<host>:8080/oauth/callback`
+4. Copy client ID/secret into `.env`
 
-Users who will connect through this MCP server need the **`snc_platform_rest_api_access`** role to make REST API calls. Without it, ServiceNow returns a 403 on all API requests (this is enforced when the system property `glide.rest.enable_role_based_access` is `true`, which is the default on newer instances).
+### Required Role
 
-To grant access:
-- **Per user**: Assign `snc_platform_rest_api_access` directly to the user record
-- **Via group**: Create a group (e.g., "MCP Users"), add the role to the group, and manage membership there
+Users should have `snc_platform_rest_api_access` for REST API access. Record-level ACLs still apply.
 
-This role only grants the ability to call REST APIs — actual record-level access is still governed by each user's existing ACLs and roles.
+---
 
-## Available Tools (18 total)
+## 🧰 Tools (18)
 
-### Incident Management
-| Tool | Description |
-|------|-------------|
-| `search_incidents` | Query incidents with filters (state, priority, assigned to me) |
-| `get_incident` | Get full incident details by number or sys_id |
-| `create_incident` | Create a new incident |
-| `update_incident` | Update fields on an existing incident |
-| `add_work_note` | Add a work note or customer-visible comment |
+### Incidents
 
-### User & Group Lookup
-| Tool | Description |
-|------|-------------|
-| `lookup_user` | Search users by name, email, or employee ID |
-| `lookup_group` | Search assignment groups by name |
-| `get_my_profile` | Get your own ServiceNow profile |
+- `search_incidents`
+- `get_incident`
+- `create_incident`
+- `update_incident`
+- `add_work_note`
 
-### Knowledge Base
-| Tool | Description |
-|------|-------------|
-| `search_knowledge` | Full-text search across knowledge bases |
-| `get_article` | Get a full knowledge article |
+### Users and Groups
 
-### Task Management
-| Tool | Description |
-|------|-------------|
-| `get_my_tasks` | Get all open tasks assigned to you |
-| `get_my_approvals` | Get your pending approvals |
-| `approve_or_reject` | Approve or reject a pending approval |
+- `lookup_user`
+- `lookup_group`
+- `get_my_profile`
 
-### Update Set Management
-| Tool | Description |
-|------|-------------|
-| `change_update_set` | Change your current in-progress update set by sys_id or exact name |
-| `create_update_set` | Create a new update set and optionally set it as current |
+### Knowledge
+
+- `search_knowledge`
+- `get_article`
+
+### Tasks and Approvals
+
+- `get_my_tasks`
+- `get_my_approvals`
+- `approve_or_reject`
+
+### Update Sets
+
+- `change_update_set`
+- `create_update_set`
 
 ### Service Catalog
-| Tool | Description |
-|------|-------------|
-| `search_catalog_items` | Search the service catalog |
-| `get_catalog_item` | Get catalog item details and form variables |
-| `submit_catalog_request` | Submit a catalog request |
 
-## Security
+- `search_catalog_items`
+- `get_catalog_item`
+- `submit_catalog_request`
 
-Several tools enforce server-side identity protections to prevent impersonation or audit trail tampering:
+---
 
-| Tool | Protection |
-|------|------------|
-| `create_incident` | `caller_id` is always set to the authenticated user — cannot be overridden via input |
-| `update_incident` | Protected audit fields (`caller_id`, `opened_by`, `sys_created_by`, `sys_updated_by`, `closed_by`, `resolved_by`, `sys_id`, `number`, `opened_at`, `sys_created_on`, `sys_updated_on`, `sys_mod_count`) are stripped from update payloads |
-| `submit_catalog_request` | `requested_for` is always set to the authenticated user — cannot be overridden via input |
-| `approve_or_reject` | Verifies the approval record belongs to the authenticated user before allowing action |
+## 🔒 Security Guarantees
 
-These protections are enforced at the server level and cannot be bypassed by the AI or user input.
+Server-side protections include:
 
-## Client Configuration
+- `create_incident`: caller identity is server-controlled
+- `update_incident`: protected audit/system fields are stripped
+- `submit_catalog_request`: requester identity is server-controlled
+- `approve_or_reject`: approval ownership is verified
 
-### Claude Desktop
+Also enforced:
+
+- `sys_id` and enum validation
+- payload sanitization
+- normalized error responses
+
+---
+
+## ⚙️ Configuration
+
+| Variable | Required | Description |
+|---|---|---|
+| `SERVICENOW_INSTANCE_URL` | Yes | ServiceNow base URL |
+| `SERVICENOW_CLIENT_ID` | Yes | OAuth client ID |
+| `SERVICENOW_CLIENT_SECRET` | Yes | OAuth client secret |
+| `OAUTH_REDIRECT_URI` | Yes | OAuth callback URL |
+| `TOKEN_ENCRYPTION_KEY` | Yes | Base64 32-byte AES key |
+| `REDIS_URL` | No | Redis URL (default `redis://localhost:6379`) |
+| `MCP_PORT` | No | Server port (default `8080`) |
+| `RATE_LIMIT_PER_USER` | No | Requests/minute/user (default `60`) |
+
+---
+
+## ✅ Testing and Quality
+
+```bash
+npm run build
+npm test
+npm run test:coverage
+```
+
+- Coverage thresholds are configured in `vitest.config.ts`
+- CI runs build + tests + coverage gate on PRs and `main`
+
+---
+
+## 🧯 Troubleshooting
+
+### 1) OAuth callback fails (`TOKEN_EXCHANGE_FAILED`)
+
+**Symptoms**
+
+- `/oauth/callback` returns 500
+- logs show token exchange failure or `invalid_grant`
+
+**Checks**
+
+- `OAUTH_REDIRECT_URI` exactly matches the ServiceNow OAuth app redirect URI
+- client ID and secret are correct
+- system clock is sane
+
+**Fix**
+
+- correct redirect/client credentials and restart server
+- re-run auth flow from `/oauth/authorize`
+
+### 2) Auth works, but API calls return 403
+
+**Symptoms**
+
+- tool calls fail with insufficient permissions
+
+**Checks**
+
+- user has `snc_platform_rest_api_access`
+- user has the needed table/record ACL permissions
+
+**Fix**
+
+- grant missing role or ACL permissions in ServiceNow
+
+### 3) Redis connectivity issues
+
+**Symptoms**
+
+- `/health` returns unhealthy
+- startup logs show Redis connection errors
+
+**Checks**
+
+- Redis is running and reachable
+- `REDIS_URL` is correct
+
+**Fix**
+
+- start Redis
+- correct `REDIS_URL`, then restart app
+
+### 4) CI fails on coverage threshold
+
+**Symptoms**
+
+- GitHub Actions fails during `npm run test:coverage`
+
+**Checks**
+
+- inspect uncovered lines in coverage output
+- ensure changed logic has matching tests
+
+**Fix**
+
+- add targeted tests
+- re-run locally with `npm run test:coverage`
+
+### 5) Tool says `AUTH_REQUIRED` after prior login
+
+**Symptoms**
+
+- tool requests re-auth unexpectedly
+
+**Checks**
+
+- refresh token may be expired/revoked
+- session mapping may be missing/expired
+
+**Fix**
+
+- re-authenticate via `/oauth/authorize`
+- confirm Redis persistence and restart behavior
+
+### Debug Command Cheat Sheet
+
+```bash
+# install + run
+npm install
+npm run dev
+
+# quality gates
+npm run build
+npm test
+npm run test:coverage
+
+# health check
+curl -s http://localhost:8080/health
+
+# local redis quick check (when redis-cli is available)
+redis-cli -u "$REDIS_URL" ping
+
+# docker compose stack quick status
+docker compose ps
+docker compose logs -f
+```
+
+---
+
+## 🤖 Agent Instruction Files
+
+- `AGENTS.md`
+- `CLAUDE.md`
+- `.github/copilot-instructions.md`
+
+Alignment workflow validates expected consistency.
+
+---
+
+## 🌐 Endpoints
+
+| Path | Method | Purpose |
+|---|---|---|
+| `/health` | GET | Health status |
+| `/oauth/authorize` | GET | Start OAuth flow |
+| `/oauth/callback` | GET | OAuth callback/token exchange |
+| `/mcp` | POST | MCP initialize + tool calls |
+| `/mcp` | GET | MCP notifications stream |
+| `/mcp` | DELETE | Close MCP session |
+
+---
+
+## Client Config Example (Claude Desktop)
 
 ```json
 {
@@ -145,39 +339,6 @@ These protections are enforced at the server level and cannot be bypassed by the
 }
 ```
 
-## Configuration
+---
 
-All configuration via environment variables. See `.env.example` for the full list.
-
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `SERVICENOW_INSTANCE_URL` | Yes | ServiceNow instance URL |
-| `SERVICENOW_CLIENT_ID` | Yes | OAuth client ID |
-| `SERVICENOW_CLIENT_SECRET` | Yes | OAuth client secret |
-| `OAUTH_REDIRECT_URI` | Yes | OAuth callback URL |
-| `TOKEN_ENCRYPTION_KEY` | Yes | Base64-encoded 32-byte AES key |
-| `REDIS_URL` | No | Redis connection string (default: `redis://localhost:6379`) |
-| `MCP_PORT` | No | Server port (default: `8080`) |
-| `RATE_LIMIT_PER_USER` | No | Requests per user per minute (default: `60`) |
-
-## Adding New Tools
-
-Copy `src/tools/_template.ts` and follow the pattern. Register your new tool in `src/tools/registry.ts`.
-
-## Testing
-
-```bash
-npm test          # Run unit tests
-npm run test:watch # Watch mode
-```
-
-## Endpoints
-
-| Path | Method | Description |
-|------|--------|-------------|
-| `/health` | GET | Health check |
-| `/oauth/authorize` | GET | Start OAuth flow |
-| `/oauth/callback` | GET | OAuth callback |
-| `/mcp` | POST | MCP initialize + tool calls |
-| `/mcp` | GET | MCP SSE notifications |
-| `/mcp` | DELETE | Close MCP session |
+Built for secure, user-scoped AI operations in ServiceNow.

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,13 +24,90 @@
         "@types/cors": "^2.8.18",
         "@types/express": "^5.0.2",
         "@types/node": "^22.15.3",
+        "@types/supertest": "^7.2.0",
         "@types/uuid": "^10.0.0",
+        "@vitest/coverage-v8": "^3.2.4",
+        "supertest": "^7.2.2",
         "tsx": "^4.19.4",
         "typescript": "^5.8.3",
         "vitest": "^3.1.4"
       },
       "engines": {
         "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -493,12 +570,72 @@
       "integrity": "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==",
       "license": "MIT"
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.27.1",
@@ -540,11 +677,45 @@
         }
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
     "node_modules/@pinojs/redact": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
       "license": "MIT"
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.59.0",
@@ -928,6 +1099,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/cors": {
       "version": "2.8.19",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
@@ -984,6 +1162,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.19.15",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
@@ -1029,12 +1214,70 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/superagent": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-7.2.0.tgz",
+      "integrity": "sha512-uh2Lv57xvggst6lCqNdFAmDSvoMG7M/HDtX4iUCquxQ5EGPtaPM5PL5Hmi7LCvOG8db7YaCPNJEeoI8s/WzIQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
+      }
+    },
     "node_modules/@types/uuid": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
@@ -1197,6 +1440,39 @@
         }
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1206,6 +1482,25 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -1233,6 +1528,16 @@
         "proxy-from-env": "^1.1.0"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -1255,6 +1560,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/bytes": {
@@ -1341,6 +1659,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/colorette": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
@@ -1357,6 +1695,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/content-disposition": {
@@ -1398,6 +1746,13 @@
       "engines": {
         "node": ">=6.6.0"
       }
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cors": {
       "version": "2.8.6",
@@ -1493,6 +1848,17 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
@@ -1519,10 +1885,24 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -1847,6 +2227,23 @@
         }
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
@@ -1882,6 +2279,24 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -1976,6 +2391,61 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -1986,6 +2456,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/has-symbols": {
@@ -2050,6 +2530,13 @@
       "engines": {
         "node": ">=16.9.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -2135,6 +2622,16 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -2146,6 +2643,76 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
     },
     "node_modules/jose": {
       "version": "6.2.1",
@@ -2203,6 +2770,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2211,6 +2785,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/math-intrinsics": {
@@ -2243,6 +2845,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -2268,6 +2893,22 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -2275,6 +2916,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -2362,6 +3013,13 @@
         "wrappy": "1"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -2378,6 +3036,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-to-regexp": {
@@ -2766,6 +3441,19 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
@@ -2917,6 +3605,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/sonic-boom": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
@@ -2974,6 +3675,110 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
@@ -2997,6 +3802,70 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/thread-stream": {
@@ -3362,6 +4231,104 @@
       },
       "bin": {
         "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"

--- a/package.json
+++ b/package.json
@@ -11,29 +11,33 @@
     "start": "node dist/index.js",
     "dev": "tsx watch src/index.ts",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "generate-key": "tsx scripts/generate-encryption-key.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.0",
-    "express": "^5.1.0",
-    "ioredis": "^5.6.1",
-    "zod": "^3.24.4",
     "axios": "^1.9.0",
-    "pino": "^9.6.0",
-    "pino-pretty": "^13.0.0",
-    "helmet": "^8.1.0",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
-    "uuid": "^11.1.0"
+    "express": "^5.1.0",
+    "helmet": "^8.1.0",
+    "ioredis": "^5.6.1",
+    "pino": "^9.6.0",
+    "pino-pretty": "^13.0.0",
+    "uuid": "^11.1.0",
+    "zod": "^3.24.4"
   },
   "devDependencies": {
-    "typescript": "^5.8.3",
-    "tsx": "^4.19.4",
-    "vitest": "^3.1.4",
-    "@types/node": "^22.15.3",
-    "@types/express": "^5.0.2",
     "@types/cors": "^2.8.18",
-    "@types/uuid": "^10.0.0"
+    "@types/express": "^5.0.2",
+    "@types/node": "^22.15.3",
+    "@types/supertest": "^7.2.0",
+    "@types/uuid": "^10.0.0",
+    "@vitest/coverage-v8": "^3.2.4",
+    "supertest": "^7.2.2",
+    "tsx": "^4.19.4",
+    "typescript": "^5.8.3",
+    "vitest": "^3.1.4"
   }
 }

--- a/tests/TEST_PLAN.md
+++ b/tests/TEST_PLAN.md
@@ -1,0 +1,50 @@
+# Test Plan (Prioritized)
+
+## Priority 1 (Security / Availability)
+
+1. `src/auth/tokenRefresh.ts`
+   - `ensureFreshToken` returns existing token when outside refresh buffer.
+   - Missing token throws `AuthRequiredError`.
+   - Refresh lock contention waits and re-reads token.
+   - Refresh `400/401` deletes token and forces re-auth.
+
+2. `src/tools/registry.ts`
+   - Missing session/user returns structured `AUTH_REQUIRED` response with `auth_url`.
+   - Tool wrapper preserves known `toolError` responses and normalizes unknown errors.
+
+3. `src/auth/oauth.ts`
+   - Callback rejects missing `code/state`, invalid state, and ServiceNow OAuth error.
+   - Success path stores token and session mapping.
+
+4. `src/server.ts`
+   - `/health` returns `200` when Redis ping succeeds and `503` when it fails.
+   - MCP routes enforce valid session behavior for `GET`/`DELETE`.
+
+## Priority 2 (API correctness)
+
+5. `src/servicenow/client.ts`
+   - Request helpers merge defaults (`sysparm_display_value`) with caller options.
+   - Error mapping for `404`, `429`, `5xx`, and generic client errors.
+
+6. `src/middleware/rateLimiter.ts`
+   - Redis Lua allow/deny branches.
+   - Fail-open behavior when Redis errors.
+
+7. `src/tools/tasks.ts`
+   - `approve_or_reject` enforces approval ownership checks and status transitions.
+
+8. `src/tools/updateSets.ts`
+   - `change_update_set` handles exact match, ambiguous name, and not found.
+
+## Implemented in this batch
+
+- `tests/unit/auth/tokenRefresh.test.ts`
+- `tests/unit/servicenow/client.test.ts`
+- `tests/unit/tools/registry.test.ts`
+- `tests/unit/middleware/rateLimiter.test.ts`
+- `tests/unit/auth/oauth.test.ts`
+- `tests/unit/server.test.ts`
+- `tests/unit/tools/tasks.test.ts`
+- `tests/unit/tools/updateSets.test.ts`
+- `tests/unit/config.test.ts`
+- `tests/unit/index.test.ts`

--- a/tests/unit/auth/oauth.test.ts
+++ b/tests/unit/auth/oauth.test.ts
@@ -1,0 +1,182 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import crypto from "node:crypto";
+import { createOAuthRouter } from "../../../src/auth/oauth.js";
+
+const axiosMocks = vi.hoisted(() => ({
+  post: vi.fn(),
+  get: vi.fn(),
+}));
+
+vi.mock("axios", () => ({
+  default: {
+    post: axiosMocks.post,
+    get: axiosMocks.get,
+  },
+}));
+
+describe("createOAuthRouter", () => {
+  const tokenStore = {
+    storeOAuthState: vi.fn(),
+    getOAuthState: vi.fn(),
+    storeToken: vi.fn(),
+    storeSessionMapping: vi.fn(),
+  };
+
+  const config = {
+    SERVICENOW_INSTANCE_URL: "https://example.service-now.com",
+    SERVICENOW_CLIENT_ID: "client-id",
+    SERVICENOW_CLIENT_SECRET: "client-secret",
+    OAUTH_REDIRECT_URI: "http://localhost:3001/oauth/callback",
+  };
+
+  function createTestApp() {
+    const app = express();
+    app.use("/oauth", createOAuthRouter(config as any, tokenStore as any));
+    return app;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+    vi.spyOn(crypto, "randomBytes").mockReturnValue(Buffer.alloc(32, 1));
+  });
+
+  it("redirects to ServiceNow and stores OAuth state on authorize", async () => {
+    tokenStore.storeOAuthState.mockResolvedValue(undefined);
+    const app = createTestApp();
+
+    const response = await request(app)
+      .get("/oauth/authorize?session_id=session-123")
+      .expect(302);
+
+    expect(tokenStore.storeOAuthState).toHaveBeenCalledWith(
+      expect.any(String),
+      { sessionId: "session-123" }
+    );
+
+    const location = response.headers.location as string;
+    expect(location).toContain("https://example.service-now.com/oauth_auth.do?");
+    expect(location).toContain("response_type=code");
+    expect(location).toContain("client_id=client-id");
+    expect(location).toContain("redirect_uri=http%3A%2F%2Flocalhost%3A3001%2Foauth%2Fcallback");
+  });
+
+  it("returns INVALID_CALLBACK when code/state are missing", async () => {
+    const app = createTestApp();
+
+    const response = await request(app).get("/oauth/callback").expect(400);
+
+    expect(response.body).toEqual({
+      success: false,
+      error: {
+        code: "INVALID_CALLBACK",
+        message: "Missing code or state parameter",
+      },
+    });
+  });
+
+  it("returns OAUTH_ERROR when provider sends an error", async () => {
+    const app = createTestApp();
+
+    const response = await request(app)
+      .get("/oauth/callback?error=access_denied")
+      .expect(400);
+
+    expect(response.body.error.code).toBe("OAUTH_ERROR");
+    expect(response.body.error.message).toContain("access_denied");
+  });
+
+  it("returns INVALID_STATE for unknown or expired OAuth state", async () => {
+    tokenStore.getOAuthState.mockResolvedValue(null);
+    const app = createTestApp();
+
+    const response = await request(app)
+      .get("/oauth/callback?code=abc&state=badstate")
+      .expect(400);
+
+    expect(tokenStore.getOAuthState).toHaveBeenCalledWith("badstate");
+    expect(response.body.error.code).toBe("INVALID_STATE");
+  });
+
+  it("stores token and session mapping on successful callback", async () => {
+    tokenStore.getOAuthState.mockResolvedValue({ sessionId: "session-abc" });
+    tokenStore.storeToken.mockResolvedValue(undefined);
+    tokenStore.storeSessionMapping.mockResolvedValue(undefined);
+
+    axiosMocks.post.mockResolvedValue({
+      data: {
+        access_token: "access-new",
+        refresh_token: "refresh-new",
+        expires_in: 1800,
+      },
+    });
+
+    axiosMocks.get.mockResolvedValue({
+      data: {
+        result: [
+          {
+            sys_id: "abc123def456abc123def456abc12345",
+            user_name: "john.doe",
+            name: "John Doe",
+          },
+        ],
+      },
+    });
+
+    const app = createTestApp();
+    const response = await request(app)
+      .get("/oauth/callback?code=authcode123&state=state-1")
+      .expect(200);
+
+    expect(axiosMocks.post).toHaveBeenCalledWith(
+      "https://example.service-now.com/oauth_token.do",
+      expect.stringContaining("grant_type=authorization_code"),
+      { headers: { "Content-Type": "application/x-www-form-urlencoded" } }
+    );
+    expect(axiosMocks.get).toHaveBeenCalledWith(
+      "https://example.service-now.com/api/now/table/sys_user",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer access-new" }),
+      })
+    );
+
+    expect(tokenStore.storeToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        access_token: "access-new",
+        refresh_token: "refresh-new",
+        user_sys_id: "abc123def456abc123def456abc12345",
+        user_name: "john.doe",
+        display_name: "John Doe",
+        expires_at: 1700001800,
+      })
+    );
+    expect(tokenStore.storeSessionMapping).toHaveBeenCalledWith(
+      "session-abc",
+      "abc123def456abc123def456abc12345"
+    );
+    expect(response.body.success).toBe(true);
+    expect(response.body.user.user_name).toBe("john.doe");
+  });
+
+  it("returns TOKEN_EXCHANGE_FAILED when token exchange fails", async () => {
+    tokenStore.getOAuthState.mockResolvedValue({ sessionId: "session-abc" });
+    axiosMocks.post.mockRejectedValue({
+      response: { status: 400, data: { error: "invalid_grant" } },
+    });
+
+    const app = createTestApp();
+    const response = await request(app)
+      .get("/oauth/callback?code=bad&state=state-1")
+      .expect(500);
+
+    expect(response.body).toEqual({
+      success: false,
+      error: {
+        code: "TOKEN_EXCHANGE_FAILED",
+        message: "Failed to exchange authorization code for tokens",
+      },
+    });
+  });
+});

--- a/tests/unit/auth/tokenRefresh.test.ts
+++ b/tests/unit/auth/tokenRefresh.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { TokenRefresher, AuthRequiredError } from "../../../src/auth/tokenRefresh.js";
+import type { StoredToken } from "../../../src/auth/tokenStore.js";
+
+const { mockAxiosPost } = vi.hoisted(() => ({
+  mockAxiosPost: vi.fn(),
+}));
+
+vi.mock("axios", () => ({
+  default: {
+    post: mockAxiosPost,
+  },
+}));
+
+const baseConfig = {
+  SERVICENOW_INSTANCE_URL: "https://example.service-now.com",
+  SERVICENOW_CLIENT_ID: "client-id",
+  SERVICENOW_CLIENT_SECRET: "client-secret",
+};
+
+describe("TokenRefresher", () => {
+  const mockTokenStore = {
+    getToken: vi.fn(),
+    storeToken: vi.fn(),
+    deleteToken: vi.fn(),
+  };
+
+  const mockRedis = {
+    set: vi.fn(),
+    del: vi.fn(),
+  };
+
+  const userSysId = "abc123def456abc123def456abc12345";
+
+  const buildToken = (expiresAt: number): StoredToken => ({
+    access_token: "access-old",
+    refresh_token: "refresh-old",
+    expires_at: expiresAt,
+    user_sys_id: userSysId,
+    user_name: "john.doe",
+    display_name: "John Doe",
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("throws AuthRequiredError when token is missing", async () => {
+    mockTokenStore.getToken.mockResolvedValue(null);
+
+    const refresher = new TokenRefresher(
+      baseConfig as any,
+      mockTokenStore as any,
+      mockRedis as any
+    );
+
+    await expect(refresher.ensureFreshToken(userSysId)).rejects.toBeInstanceOf(
+      AuthRequiredError
+    );
+  });
+
+  it("returns existing token when outside refresh buffer", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+    const now = Math.floor(Date.now() / 1000);
+    const freshToken = buildToken(now + 120);
+    mockTokenStore.getToken.mockResolvedValue(freshToken);
+
+    const refresher = new TokenRefresher(
+      baseConfig as any,
+      mockTokenStore as any,
+      mockRedis as any
+    );
+
+    const token = await refresher.ensureFreshToken(userSysId);
+
+    expect(token).toEqual(freshToken);
+    expect(mockRedis.set).not.toHaveBeenCalled();
+    expect(mockAxiosPost).not.toHaveBeenCalled();
+  });
+
+  it("refreshes expiring token and stores updated values", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+    const now = Math.floor(Date.now() / 1000);
+    const staleToken = buildToken(now + 30);
+
+    mockTokenStore.getToken
+      .mockResolvedValueOnce(staleToken)
+      .mockResolvedValueOnce(staleToken);
+    mockRedis.set.mockResolvedValue("OK");
+    mockRedis.del.mockResolvedValue(1);
+    mockTokenStore.storeToken.mockResolvedValue(undefined);
+    mockAxiosPost.mockResolvedValue({
+      data: {
+        access_token: "access-new",
+        expires_in: 1800,
+      },
+    });
+
+    const refresher = new TokenRefresher(
+      baseConfig as any,
+      mockTokenStore as any,
+      mockRedis as any
+    );
+
+    const updated = await refresher.ensureFreshToken(userSysId);
+
+    expect(mockRedis.set).toHaveBeenCalledWith(
+      `token_refresh_lock:${userSysId}`,
+      "1",
+      "EX",
+      10,
+      "NX"
+    );
+    expect(mockAxiosPost).toHaveBeenCalledWith(
+      "https://example.service-now.com/oauth_token.do",
+      expect.stringContaining("grant_type=refresh_token"),
+      { headers: { "Content-Type": "application/x-www-form-urlencoded" } }
+    );
+    expect(mockTokenStore.storeToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        access_token: "access-new",
+        refresh_token: "refresh-old",
+        expires_at: now + 1800,
+      })
+    );
+    expect(updated.access_token).toBe("access-new");
+    expect(updated.refresh_token).toBe("refresh-old");
+    expect(mockRedis.del).toHaveBeenCalledWith(`token_refresh_lock:${userSysId}`);
+  });
+
+  it("waits and returns refreshed token when lock is already held", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-10T00:00:00.000Z"));
+    const now = Math.floor(Date.now() / 1000);
+    const staleToken = buildToken(now + 5);
+    const refreshedToken = buildToken(now + 3600);
+
+    mockTokenStore.getToken
+      .mockResolvedValueOnce(staleToken)
+      .mockResolvedValueOnce(refreshedToken);
+    mockRedis.set.mockResolvedValue(null);
+
+    const refresher = new TokenRefresher(
+      baseConfig as any,
+      mockTokenStore as any,
+      mockRedis as any
+    );
+
+    const pending = refresher.ensureFreshToken(userSysId);
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await pending;
+
+    expect(result).toEqual(refreshedToken);
+    expect(mockAxiosPost).not.toHaveBeenCalled();
+    expect(mockRedis.del).not.toHaveBeenCalled();
+  });
+
+  it("deletes token and throws AuthRequiredError when refresh is unauthorized", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+    const now = Math.floor(Date.now() / 1000);
+    const staleToken = buildToken(now + 10);
+
+    mockTokenStore.getToken
+      .mockResolvedValueOnce(staleToken)
+      .mockResolvedValueOnce(staleToken);
+    mockRedis.set.mockResolvedValue("OK");
+    mockRedis.del.mockResolvedValue(1);
+    mockAxiosPost.mockRejectedValue({ response: { status: 401 } });
+
+    const refresher = new TokenRefresher(
+      baseConfig as any,
+      mockTokenStore as any,
+      mockRedis as any
+    );
+
+    await expect(refresher.ensureFreshToken(userSysId)).rejects.toBeInstanceOf(
+      AuthRequiredError
+    );
+    expect(mockTokenStore.deleteToken).toHaveBeenCalledWith(userSysId);
+    expect(mockRedis.del).toHaveBeenCalledWith(`token_refresh_lock:${userSysId}`);
+  });
+});

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("loadConfig", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+    delete process.env.REDIS_URL;
+    delete process.env.MCP_PORT;
+    delete process.env.NODE_ENV;
+    delete process.env.LOG_LEVEL;
+    delete process.env.RATE_LIMIT_PER_USER;
+    delete process.env.ALLOWED_ORIGINS;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it("loads config with defaults and transforms", async () => {
+    process.env.SERVICENOW_INSTANCE_URL = "https://example.service-now.com///";
+    process.env.SERVICENOW_CLIENT_ID = "client-id";
+    process.env.SERVICENOW_CLIENT_SECRET = "client-secret";
+    process.env.OAUTH_REDIRECT_URI = "http://localhost:3001/oauth/callback";
+    process.env.TOKEN_ENCRYPTION_KEY = Buffer.alloc(32, 1).toString("base64");
+    process.env.ALLOWED_ORIGINS = "https://a.example.com, https://b.example.com";
+
+    const { loadConfig } = await import("../../src/config.js");
+    const config = loadConfig();
+
+    expect(config.SERVICENOW_INSTANCE_URL).toBe("https://example.service-now.com");
+    expect(config.REDIS_URL).toBe("redis://localhost:6379");
+    expect(config.MCP_PORT).toBe(8080);
+    expect(config.NODE_ENV).toBe("development");
+    expect(config.LOG_LEVEL).toBe("info");
+    expect(config.RATE_LIMIT_PER_USER).toBe(60);
+    expect(config.ALLOWED_ORIGINS).toEqual([
+      "https://a.example.com",
+      "https://b.example.com",
+    ]);
+  });
+
+  it("returns cached config instance on repeated calls", async () => {
+    process.env.SERVICENOW_INSTANCE_URL = "https://cached.example.com/";
+    process.env.SERVICENOW_CLIENT_ID = "client-id";
+    process.env.SERVICENOW_CLIENT_SECRET = "client-secret";
+    process.env.OAUTH_REDIRECT_URI = "http://localhost:3001/oauth/callback";
+    process.env.TOKEN_ENCRYPTION_KEY = Buffer.alloc(32, 2).toString("base64");
+
+    const { loadConfig } = await import("../../src/config.js");
+    const first = loadConfig();
+
+    process.env.SERVICENOW_INSTANCE_URL = "https://different.example.com";
+    const second = loadConfig();
+
+    expect(second).toBe(first);
+    expect(second.SERVICENOW_INSTANCE_URL).toBe("https://cached.example.com");
+  });
+
+  it("prints validation errors and exits for invalid configuration", async () => {
+    process.env.SERVICENOW_INSTANCE_URL = "not-a-url";
+    process.env.SERVICENOW_CLIENT_ID = "";
+    process.env.SERVICENOW_CLIENT_SECRET = "";
+    process.env.OAUTH_REDIRECT_URI = "bad-uri";
+    process.env.TOKEN_ENCRYPTION_KEY = "";
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(((code?: number) => {
+        throw new Error(`process.exit:${code}`);
+      }) as never);
+
+    const { loadConfig } = await import("../../src/config.js");
+
+    expect(() => loadConfig()).toThrow("process.exit:1");
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Configuration validation failed:")
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("index startup", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("starts server, registers signal handlers, and performs shutdown sequence", async () => {
+    const config = {
+      REDIS_URL: "redis://localhost:6379",
+      MCP_PORT: 3001,
+    };
+
+    const logger = {
+      info: vi.fn(),
+      error: vi.fn(),
+      fatal: vi.fn(),
+    };
+
+    const serverClose = vi.fn();
+    const listen = vi.fn((_port: number, callback: () => void) => {
+      callback();
+      return { close: serverClose };
+    });
+
+    const app = { listen };
+
+    const redisOn = vi.fn();
+    const redisQuit = vi.fn().mockResolvedValue(undefined);
+    const redis = {
+      on: redisOn,
+      quit: redisQuit,
+    };
+
+    const loadConfig = vi.fn().mockReturnValue(config);
+    const createRedisClient = vi.fn().mockReturnValue(redis);
+    const createApp = vi.fn().mockResolvedValue(app);
+
+    const processOnSpy = vi.spyOn(process, "on");
+    const processExitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(((code?: number) => {
+        throw new Error(`process.exit:${code}`);
+      }) as never);
+
+    vi.doMock("../../src/config.js", () => ({ loadConfig }));
+    vi.doMock("../../src/utils/logger.js", () => ({ logger }));
+    vi.doMock("../../src/server.js", () => ({ createApp }));
+    vi.doMock("../../src/auth/tokenStore.js", () => ({ createRedisClient }));
+
+    await import("../../src/index.js");
+    await Promise.resolve();
+
+    expect(loadConfig).toHaveBeenCalledTimes(1);
+    expect(createRedisClient).toHaveBeenCalledWith("redis://localhost:6379");
+    expect(createApp).toHaveBeenCalledWith(config, redis);
+    expect(listen).toHaveBeenCalledWith(3001, expect.any(Function));
+    expect(redisOn).toHaveBeenCalledWith("error", expect.any(Function));
+    expect(redisOn).toHaveBeenCalledWith("connect", expect.any(Function));
+
+    const sigtermCall = processOnSpy.mock.calls.find(
+      ([signal]) => signal === "SIGTERM"
+    );
+    const sigintCall = processOnSpy.mock.calls.find(
+      ([signal]) => signal === "SIGINT"
+    );
+
+    expect(sigtermCall).toBeTruthy();
+    expect(sigintCall).toBeTruthy();
+
+    const shutdownHandler = sigtermCall?.[1] as () => Promise<void>;
+    await expect(shutdownHandler()).rejects.toThrow("process.exit:0");
+
+    expect(serverClose).toHaveBeenCalledTimes(1);
+    expect(redisQuit).toHaveBeenCalledTimes(1);
+    expect(processExitSpy).toHaveBeenCalledWith(0);
+    expect(logger.fatal).not.toHaveBeenCalled();
+  });
+
+  it("logs fatal and exits with code 1 when startup fails", async () => {
+    const logger = {
+      info: vi.fn(),
+      error: vi.fn(),
+      fatal: vi.fn(),
+    };
+
+    const startupError = new Error("createApp failed");
+    const loadConfig = vi.fn().mockReturnValue({
+      REDIS_URL: "redis://localhost:6379",
+      MCP_PORT: 3001,
+    });
+    const createRedisClient = vi.fn().mockReturnValue({ on: vi.fn(), quit: vi.fn() });
+    const createApp = vi.fn().mockRejectedValue(startupError);
+
+    const processExitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation((() => {
+        return undefined as never;
+      }) as never);
+
+    vi.doMock("../../src/config.js", () => ({ loadConfig }));
+    vi.doMock("../../src/utils/logger.js", () => ({ logger }));
+    vi.doMock("../../src/server.js", () => ({ createApp }));
+    vi.doMock("../../src/auth/tokenStore.js", () => ({ createRedisClient }));
+
+    await import("../../src/index.js");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(logger.fatal).toHaveBeenCalledWith(
+      { err: startupError },
+      "Failed to start server"
+    );
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/tests/unit/middleware/rateLimiter.test.ts
+++ b/tests/unit/middleware/rateLimiter.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { RateLimiter } from "../../../src/middleware/rateLimiter.js";
+
+describe("RateLimiter", () => {
+  const redis = {
+    eval: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+  });
+
+  it("returns true when Redis script allows request", async () => {
+    redis.eval.mockResolvedValue(1);
+    const limiter = new RateLimiter(redis as any, 60);
+
+    const allowed = await limiter.checkLimit("abc123def456abc123def456abc12345");
+
+    expect(allowed).toBe(true);
+    expect(redis.eval).toHaveBeenCalledWith(
+      expect.any(String),
+      1,
+      "ratelimit:abc123def456abc123def456abc12345",
+      60,
+      1700000000
+    );
+  });
+
+  it("returns false when Redis script denies request", async () => {
+    redis.eval.mockResolvedValue(0);
+    const limiter = new RateLimiter(redis as any, 10);
+
+    const allowed = await limiter.checkLimit("user-1");
+
+    expect(allowed).toBe(false);
+  });
+
+  it("fails open when Redis errors", async () => {
+    redis.eval.mockRejectedValue(new Error("Redis unavailable"));
+    const limiter = new RateLimiter(redis as any, 10);
+
+    const allowed = await limiter.checkLimit("user-1");
+
+    expect(allowed).toBe(true);
+  });
+});

--- a/tests/unit/server.test.ts
+++ b/tests/unit/server.test.ts
@@ -1,0 +1,147 @@
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createApp } from "../../src/server.js";
+
+const mocks = vi.hoisted(() => ({
+  connect: vi.fn(),
+  registerAllTools: vi.fn(),
+  transportInstances: [] as Array<{
+    handleRequest: ReturnType<typeof vi.fn>;
+    close: ReturnType<typeof vi.fn>;
+    onclose?: () => void;
+    sessionId?: string;
+  }> ,
+}));
+
+vi.mock("@modelcontextprotocol/sdk/server/mcp.js", () => ({
+  McpServer: class {
+    async connect(transport: unknown) {
+      return mocks.connect(transport);
+    }
+  },
+}));
+
+vi.mock("@modelcontextprotocol/sdk/server/streamableHttp.js", () => ({
+  StreamableHTTPServerTransport: class {
+    public onclose?: () => void;
+    public handleRequest: ReturnType<typeof vi.fn>;
+    public close: ReturnType<typeof vi.fn>;
+    public sessionId?: string;
+    private initialized = false;
+
+    constructor(private opts: { sessionIdGenerator: () => string; onsessioninitialized: (sessionId: string) => void }) {
+      this.handleRequest = vi.fn(async (_req, res) => {
+        if (!this.initialized) {
+          this.initialized = true;
+          this.sessionId = this.opts.sessionIdGenerator();
+          this.opts.onsessioninitialized(this.sessionId);
+        }
+        res.status(200).json({ ok: true });
+      });
+
+      this.close = vi.fn(async () => {
+        if (this.onclose) {
+          this.onclose();
+        }
+      });
+
+      mocks.transportInstances.push(this);
+    }
+  },
+}));
+
+vi.mock("../../src/tools/registry.js", () => ({
+  registerAllTools: mocks.registerAllTools,
+}));
+
+describe("createApp", () => {
+  const baseConfig = {
+    TOKEN_ENCRYPTION_KEY: Buffer.alloc(32, 1).toString("base64"),
+    ALLOWED_ORIGINS: ["*"],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.transportInstances.length = 0;
+  });
+
+  it("returns healthy status when redis ping succeeds", async () => {
+    const redis = {
+      ping: vi.fn().mockResolvedValue("PONG"),
+    };
+    const app = await createApp(baseConfig as any, redis as any);
+
+    const response = await request(app).get("/health").expect(200);
+
+    expect(response.body.status).toBe("healthy");
+    expect(response.body.redis).toBe("connected");
+  });
+
+  it("returns unhealthy status when redis ping fails", async () => {
+    const redis = {
+      ping: vi.fn().mockRejectedValue(new Error("redis down")),
+    };
+    const app = await createApp(baseConfig as any, redis as any);
+
+    const response = await request(app).get("/health").expect(503);
+
+    expect(response.body.status).toBe("unhealthy");
+    expect(response.body.redis).toBe("disconnected");
+  });
+
+  it("rejects GET /mcp with missing or unknown session", async () => {
+    const redis = { ping: vi.fn().mockResolvedValue("PONG") };
+    const app = await createApp(baseConfig as any, redis as any);
+
+    await request(app).get("/mcp").expect(400);
+    await request(app).get("/mcp").set("mcp-session-id", "missing").expect(400);
+  });
+
+  it("rejects DELETE /mcp for missing session", async () => {
+    const redis = { ping: vi.fn().mockResolvedValue("PONG") };
+    const app = await createApp(baseConfig as any, redis as any);
+
+    await request(app).delete("/mcp").expect(404);
+    await request(app).delete("/mcp").set("mcp-session-id", "missing").expect(404);
+  });
+
+  it("creates session on first POST and reuses it on subsequent POST", async () => {
+    const redis = { ping: vi.fn().mockResolvedValue("PONG") };
+    const app = await createApp(baseConfig as any, redis as any);
+
+    await request(app).post("/mcp").send({}).expect(200);
+
+    expect(mocks.connect).toHaveBeenCalledTimes(1);
+    expect(mocks.transportInstances).toHaveLength(1);
+
+    const firstTransport = mocks.transportInstances[0];
+    const sessionId = firstTransport.sessionId;
+    expect(sessionId).toBeTruthy();
+
+    await request(app)
+      .post("/mcp")
+      .set("mcp-session-id", sessionId!)
+      .send({})
+      .expect(200);
+
+    expect(mocks.connect).toHaveBeenCalledTimes(1);
+    expect(firstTransport.handleRequest).toHaveBeenCalledTimes(2);
+  });
+
+  it("closes and removes session on DELETE /mcp", async () => {
+    const redis = { ping: vi.fn().mockResolvedValue("PONG") };
+    const app = await createApp(baseConfig as any, redis as any);
+
+    await request(app).post("/mcp").send({}).expect(200);
+    const transport = mocks.transportInstances[0];
+    const sessionId = transport.sessionId!;
+
+    await request(app)
+      .delete("/mcp")
+      .set("mcp-session-id", sessionId)
+      .expect(200);
+
+    expect(transport.close).toHaveBeenCalledTimes(1);
+    await request(app).get("/mcp").set("mcp-session-id", sessionId).expect(400);
+  });
+});

--- a/tests/unit/servicenow/client.test.ts
+++ b/tests/unit/servicenow/client.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ServiceNowClient } from "../../../src/servicenow/client.js";
+
+const axiosMocks = vi.hoisted(() => ({
+  create: vi.fn(),
+  get: vi.fn(),
+  post: vi.fn(),
+  patch: vi.fn(),
+}));
+
+vi.mock("axios", () => ({
+  default: {
+    create: axiosMocks.create,
+  },
+}));
+
+describe("ServiceNowClient", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    axiosMocks.create.mockReturnValue({
+      get: axiosMocks.get,
+      post: axiosMocks.post,
+      patch: axiosMocks.patch,
+    });
+  });
+
+  it("creates axios instance with auth headers", () => {
+    new ServiceNowClient("https://example.service-now.com", "token-123");
+
+    expect(axiosMocks.create).toHaveBeenCalledWith({
+      baseURL: "https://example.service-now.com",
+      headers: {
+        Authorization: "Bearer token-123",
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      timeout: 30000,
+    });
+  });
+
+  it("merges default and custom params for GET", async () => {
+    axiosMocks.get.mockResolvedValue({
+      status: 200,
+      data: { result: [{ sys_id: "123" }] },
+      headers: { etag: "abc" },
+    });
+
+    const client = new ServiceNowClient("https://example.service-now.com", "token-123");
+    const result = await client.get("/api/now/table/incident", {
+      params: { sysparm_limit: 1 },
+      headers: { "X-Trace": "trace-1" },
+    });
+
+    expect(axiosMocks.get).toHaveBeenCalledWith("/api/now/table/incident", {
+      params: {
+        sysparm_display_value: "true",
+        sysparm_limit: 1,
+      },
+      headers: { "X-Trace": "trace-1" },
+    });
+    expect(result).toEqual({
+      data: { result: [{ sys_id: "123" }] },
+      headers: { etag: "abc" },
+    });
+  });
+
+  it("maps 404 responses to record-not-found message", async () => {
+    axiosMocks.get.mockRejectedValue({
+      response: {
+        status: 404,
+        data: { error: "not found" },
+      },
+    });
+
+    const client = new ServiceNowClient("https://example.service-now.com", "token-123");
+
+    await expect(client.get("/api/now/table/incident/bad-id")).rejects.toMatchObject({
+      statusCode: 404,
+      responseBody: { error: "not found" },
+      message: "Record not found",
+    });
+  });
+
+  it("maps 5xx responses to ServiceNow unavailable", async () => {
+    axiosMocks.post.mockRejectedValue({
+      response: {
+        status: 503,
+        data: { error: "maintenance" },
+      },
+    });
+
+    const client = new ServiceNowClient("https://example.service-now.com", "token-123");
+
+    await expect(client.post("/api/now/table/incident", { short_description: "x" })).rejects.toMatchObject({
+      statusCode: 503,
+      message: "ServiceNow unavailable",
+    });
+  });
+
+  it("maps non-special client errors to generic API message", async () => {
+    axiosMocks.patch.mockRejectedValue({
+      response: {
+        status: 400,
+        data: { error: "bad request" },
+      },
+    });
+
+    const client = new ServiceNowClient("https://example.service-now.com", "token-123");
+
+    await expect(client.patch("/api/now/table/incident/1", { state: "2" })).rejects.toMatchObject({
+      statusCode: 400,
+      message: "ServiceNow API error (400)",
+    });
+  });
+});

--- a/tests/unit/tools/registry.test.ts
+++ b/tests/unit/tools/registry.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ToolContext } from "../../../src/tools/registry.js";
+import { registerAllTools } from "../../../src/tools/registry.js";
+
+const mocks = vi.hoisted(() => ({
+  registerUserTools: vi.fn(),
+  registerIncidentTools: vi.fn(),
+  registerKnowledgeTools: vi.fn(),
+  registerTaskTools: vi.fn(),
+  registerCatalogTools: vi.fn(),
+  registerUpdateSetTools: vi.fn(),
+  checkLimit: vi.fn(),
+  ensureFreshToken: vi.fn(),
+  createToolError: vi.fn(),
+  handleToolError: vi.fn(),
+  loggerInfo: vi.fn(),
+}));
+
+vi.mock("../../../src/tools/users.js", () => ({
+  registerUserTools: mocks.registerUserTools,
+}));
+
+vi.mock("../../../src/tools/incidents.js", () => ({
+  registerIncidentTools: mocks.registerIncidentTools,
+}));
+
+vi.mock("../../../src/tools/knowledge.js", () => ({
+  registerKnowledgeTools: mocks.registerKnowledgeTools,
+}));
+
+vi.mock("../../../src/tools/tasks.js", () => ({
+  registerTaskTools: mocks.registerTaskTools,
+}));
+
+vi.mock("../../../src/tools/catalog.js", () => ({
+  registerCatalogTools: mocks.registerCatalogTools,
+}));
+
+vi.mock("../../../src/tools/updateSets.js", () => ({
+  registerUpdateSetTools: mocks.registerUpdateSetTools,
+}));
+
+vi.mock("../../../src/middleware/rateLimiter.js", () => ({
+  RateLimiter: class {
+    async checkLimit(userSysId: string) {
+      return mocks.checkLimit(userSysId);
+    }
+  },
+}));
+
+vi.mock("../../../src/auth/tokenRefresh.js", () => {
+  class AuthRequiredError extends Error {
+    public readonly code = "AUTH_REQUIRED";
+
+    constructor(public readonly userSysId?: string) {
+      super("Authentication required");
+      this.name = "AuthRequiredError";
+    }
+  }
+
+  return {
+    TokenRefresher: class {
+      async ensureFreshToken(userSysId: string) {
+        return mocks.ensureFreshToken(userSysId);
+      }
+    },
+    AuthRequiredError,
+  };
+});
+
+vi.mock("../../../src/servicenow/client.js", () => ({
+  ServiceNowClient: class {
+    constructor(
+      public readonly instanceUrl: string,
+      public readonly accessToken: string
+    ) {}
+  },
+}));
+
+vi.mock("../../../src/middleware/errorHandler.js", () => ({
+  createToolError: mocks.createToolError,
+  handleToolError: mocks.handleToolError,
+}));
+
+vi.mock("../../../src/utils/logger.js", () => ({
+  logger: {
+    info: mocks.loggerInfo,
+  },
+}));
+
+type WrapHandler = <T>(
+  handler: (ctx: ToolContext, args: T) => Promise<unknown>
+) => (args: T) => Promise<{ content: { type: "text"; text: string }[]; isError?: boolean }>;
+
+describe("registerAllTools", () => {
+  const tokenStore = {
+    getUserForSession: vi.fn(),
+  };
+
+  const config = {
+    OAUTH_REDIRECT_URI: "http://localhost:3001/oauth/callback",
+    RATE_LIMIT_PER_USER: 60,
+    SERVICENOW_INSTANCE_URL: "https://example.service-now.com",
+  };
+
+  const resolvedToken = {
+    access_token: "access-token",
+    refresh_token: "refresh-token",
+    expires_at: 1_900_000_000,
+    user_sys_id: "abc123def456abc123def456abc12345",
+    user_name: "john.doe",
+    display_name: "John Doe",
+  };
+
+  let capturedWrap: WrapHandler;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedWrap = undefined as unknown as WrapHandler;
+
+    mocks.registerUserTools.mockImplementation((_server: unknown, wrap: WrapHandler) => {
+      capturedWrap = wrap;
+    });
+    mocks.registerIncidentTools.mockImplementation(() => {});
+    mocks.registerKnowledgeTools.mockImplementation(() => {});
+    mocks.registerTaskTools.mockImplementation(() => {});
+    mocks.registerCatalogTools.mockImplementation(() => {});
+    mocks.registerUpdateSetTools.mockImplementation(() => {});
+
+    mocks.checkLimit.mockResolvedValue(true);
+    mocks.ensureFreshToken.mockResolvedValue(resolvedToken);
+    mocks.createToolError.mockImplementation(
+      (code: string, message: string, details?: unknown) => ({
+        success: false,
+        error: {
+          code,
+          message,
+          details,
+          reference_id: "ref-1",
+        },
+      })
+    );
+    mocks.handleToolError.mockReturnValue({
+      success: false,
+      error: {
+        code: "UNEXPECTED_ERROR",
+        message: "normalized error",
+        reference_id: "ref-2",
+      },
+    });
+  });
+
+  it("returns AUTH_REQUIRED with auth_url when session has no user mapping", async () => {
+    tokenStore.getUserForSession.mockResolvedValue(null);
+
+    registerAllTools(
+      {} as any,
+      () => "session-123",
+      config as any,
+      {} as any,
+      tokenStore as any
+    );
+
+    const handler = vi.fn(async () => ({ success: true }));
+    const wrapped = capturedWrap(handler);
+    const response = await wrapped({} as Record<string, never>);
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(response.isError).toBe(true);
+
+    const parsed = JSON.parse(response.content[0].text);
+    expect(parsed.error.code).toBe("AUTH_REQUIRED");
+    expect(parsed.error.details.auth_url).toBe(
+      "http://localhost:3001/oauth/authorize?session_id=session-123"
+    );
+  });
+
+  it("passes through known toolError payloads from handlers", async () => {
+    tokenStore.getUserForSession.mockResolvedValue("abc123def456abc123def456abc12345");
+
+    registerAllTools(
+      {} as any,
+      () => "session-123",
+      config as any,
+      {} as any,
+      tokenStore as any
+    );
+
+    const knownToolError = {
+      success: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Bad input",
+        reference_id: "custom-ref",
+      },
+    };
+
+    const wrapped = capturedWrap(async () => {
+      throw Object.assign(new Error("Validation failed"), {
+        toolError: knownToolError,
+      });
+    });
+
+    const response = await wrapped({} as Record<string, never>);
+
+    expect(response.isError).toBe(true);
+    expect(JSON.parse(response.content[0].text)).toEqual(knownToolError);
+    expect(mocks.handleToolError).not.toHaveBeenCalled();
+  });
+
+  it("normalizes unexpected errors using handleToolError", async () => {
+    tokenStore.getUserForSession.mockResolvedValue("abc123def456abc123def456abc12345");
+
+    registerAllTools(
+      {} as any,
+      () => "session-123",
+      config as any,
+      {} as any,
+      tokenStore as any
+    );
+
+    const boom = new Error("Boom");
+    const wrapped = capturedWrap(async () => {
+      throw boom;
+    });
+
+    const response = await wrapped({} as Record<string, never>);
+
+    expect(response.isError).toBe(true);
+    expect(JSON.parse(response.content[0].text)).toEqual({
+      success: false,
+      error: {
+        code: "UNEXPECTED_ERROR",
+        message: "normalized error",
+        reference_id: "ref-2",
+      },
+    });
+    expect(mocks.handleToolError).toHaveBeenCalledWith(boom);
+  });
+});

--- a/tests/unit/tools/tasks.test.ts
+++ b/tests/unit/tools/tasks.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerTaskTools } from "../../../src/tools/tasks.js";
+import type { ToolContext } from "../../../src/tools/registry.js";
+
+type WrappedHandler<T = unknown> = (args: T) => Promise<unknown>;
+
+describe("registerTaskTools", () => {
+  const userSysId = "abc123def456abc123def456abc12345";
+
+  function setup() {
+    const handlers: Record<string, WrappedHandler> = {};
+
+    const server = {
+      tool: vi.fn(
+        (
+          name: string,
+          _description: string,
+          _schema: unknown,
+          handler: WrappedHandler
+        ) => {
+          handlers[name] = handler;
+        }
+      ),
+    };
+
+    const snClient = {
+      get: vi.fn(),
+      patch: vi.fn(),
+      post: vi.fn(),
+    };
+
+    const ctx: ToolContext = {
+      snClient: snClient as unknown as ToolContext["snClient"],
+      userSysId,
+      userName: "john.doe",
+      displayName: "John Doe",
+    };
+
+    const wrapHandler = <T>(
+      handler: (context: ToolContext, args: T) => Promise<unknown>
+    ) => {
+      return async (args: T) => handler(ctx, args);
+    };
+
+    registerTaskTools(server as any, wrapHandler);
+
+    return { handlers, snClient, server };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns validation error for invalid approval sys_id", async () => {
+    const { handlers, snClient } = setup();
+
+    const result = (await handlers.approve_or_reject({
+      sys_id: "bad-id",
+      action: "approved",
+    })) as any;
+
+    expect(result).toEqual({
+      success: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Invalid sys_id format",
+      },
+    });
+    expect(snClient.get).not.toHaveBeenCalled();
+    expect(snClient.patch).not.toHaveBeenCalled();
+  });
+
+  it("returns forbidden when approval does not belong to authenticated user", async () => {
+    const { handlers, snClient } = setup();
+    const approvalId = "0123456789abcdef0123456789abcdef";
+
+    snClient.get.mockResolvedValue({ data: { result: [] }, headers: {} });
+
+    const result = (await handlers.approve_or_reject({
+      sys_id: approvalId,
+      action: "rejected",
+    })) as any;
+
+    expect(snClient.get).toHaveBeenCalledWith(
+      "/api/now/table/sysapproval_approver",
+      {
+        params: {
+          sysparm_query: `sys_id=${approvalId}^approver=${userSysId}`,
+          sysparm_limit: 1,
+          sysparm_fields: "sys_id",
+        },
+      }
+    );
+    expect(result).toEqual({
+      success: false,
+      error: {
+        code: "FORBIDDEN",
+        message:
+          "Approval not found or does not belong to the authenticated user",
+      },
+    });
+  });
+
+  it("approves request with optional comments", async () => {
+    const { handlers, snClient } = setup();
+    const approvalId = "fedcba9876543210fedcba9876543210";
+
+    snClient.get.mockResolvedValue({
+      data: { result: [{ sys_id: approvalId }] },
+      headers: {},
+    });
+    snClient.patch.mockResolvedValue({
+      data: {
+        result: {
+          sys_id: approvalId,
+          state: "approved",
+          comments: "LGTM",
+        },
+      },
+      headers: {},
+    });
+
+    const result = (await handlers.approve_or_reject({
+      sys_id: approvalId,
+      action: "approved",
+      comments: "LGTM",
+    })) as any;
+
+    expect(snClient.patch).toHaveBeenCalledWith(
+      `/api/now/table/sysapproval_approver/${approvalId}`,
+      {
+        state: "approved",
+        comments: "LGTM",
+      }
+    );
+    expect(result).toEqual({
+      success: true,
+      data: {
+        sys_id: approvalId,
+        state: "approved",
+        comments: "LGTM",
+      },
+      message: "Approval approved successfully",
+    });
+  });
+
+  it("builds get_my_tasks query scoped to authenticated user", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.get.mockResolvedValue({
+      data: { result: [{ sys_id: "task-1" }] },
+      headers: { "x-total-count": "1" },
+    });
+
+    const result = (await handlers.get_my_tasks({
+      limit: 25,
+      offset: 5,
+    })) as any;
+
+    expect(snClient.get).toHaveBeenCalledWith("/api/now/table/task", {
+      params: {
+        sysparm_query: `assigned_to=${userSysId}^active=true^ORDERBYDESCsys_updated_on`,
+        sysparm_limit: 25,
+        sysparm_offset: 5,
+        sysparm_fields:
+          "sys_id,number,short_description,state,priority,assigned_to,assignment_group,sys_class_name,opened_at,due_date,sys_updated_on",
+      },
+    });
+    expect(result.metadata).toEqual({
+      total_count: 1,
+      returned_count: 1,
+      offset: 5,
+    });
+  });
+});

--- a/tests/unit/tools/updateSets.test.ts
+++ b/tests/unit/tools/updateSets.test.ts
@@ -1,0 +1,272 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerUpdateSetTools } from "../../../src/tools/updateSets.js";
+import type { ToolContext } from "../../../src/tools/registry.js";
+
+type WrappedHandler<T = unknown> = (args: T) => Promise<unknown>;
+
+describe("registerUpdateSetTools", () => {
+  const userSysId = "abc123def456abc123def456abc12345";
+
+  function setup() {
+    const handlers: Record<string, WrappedHandler> = {};
+
+    const server = {
+      tool: vi.fn(
+        (
+          name: string,
+          _description: string,
+          _schema: unknown,
+          handler: WrappedHandler
+        ) => {
+          handlers[name] = handler;
+        }
+      ),
+    };
+
+    const snClient = {
+      get: vi.fn(),
+      patch: vi.fn(),
+      post: vi.fn(),
+    };
+
+    const ctx: ToolContext = {
+      snClient: snClient as unknown as ToolContext["snClient"],
+      userSysId,
+      userName: "john.doe",
+      displayName: "John Doe",
+    };
+
+    const wrapHandler = <T>(
+      handler: (context: ToolContext, args: T) => Promise<unknown>
+    ) => {
+      return async (args: T) => handler(ctx, args);
+    };
+
+    registerUpdateSetTools(server as any, wrapHandler);
+
+    return { handlers, snClient };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns NOT_FOUND when no in-progress update set matches identifier", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.get.mockResolvedValueOnce({ data: { result: [] }, headers: {} });
+
+    const result = (await handlers.change_update_set({
+      identifier: "No Match",
+    })) as any;
+
+    expect(result).toEqual({
+      success: false,
+      error: {
+        code: "NOT_FOUND",
+        message: "No in-progress update set found for the provided identifier.",
+      },
+    });
+    expect(snClient.patch).not.toHaveBeenCalled();
+    expect(snClient.post).not.toHaveBeenCalled();
+  });
+
+  it("returns AMBIGUOUS_MATCH when multiple name matches exist", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.get.mockResolvedValueOnce({
+      data: {
+        result: [
+          {
+            sys_id: "0123456789abcdef0123456789abcdef",
+            name: "Feature Work",
+            state: "in progress",
+            sys_updated_on: "2026-03-10 10:00:00",
+          },
+          {
+            sys_id: "fedcba9876543210fedcba9876543210",
+            name: "Feature Work",
+            state: "in progress",
+            sys_updated_on: "2026-03-10 09:00:00",
+          },
+        ],
+      },
+      headers: {},
+    });
+
+    const result = (await handlers.change_update_set({
+      identifier: "Feature Work",
+    })) as any;
+
+    expect(result.success).toBe(false);
+    expect(result.error.code).toBe("AMBIGUOUS_MATCH");
+    expect(result.error.details.matches).toHaveLength(2);
+    expect(snClient.patch).not.toHaveBeenCalled();
+    expect(snClient.post).not.toHaveBeenCalled();
+  });
+
+  it("patches existing user preference when changing update set by sys_id", async () => {
+    const { handlers, snClient } = setup();
+    const targetId = "0123456789abcdef0123456789abcdef";
+
+    snClient.get
+      .mockResolvedValueOnce({
+        data: {
+          result: [
+            {
+              sys_id: targetId,
+              name: "Feature A",
+              state: "in progress",
+              application: "x_app",
+            },
+          ],
+        },
+        headers: {},
+      })
+      .mockResolvedValueOnce({
+        data: {
+          result: [
+            {
+              sys_id: "pref-1",
+              name: "sys_update_set",
+              user: userSysId,
+              value: "old-id",
+            },
+          ],
+        },
+        headers: {},
+      });
+    snClient.patch.mockResolvedValue({ data: { result: {} }, headers: {} });
+
+    const result = (await handlers.change_update_set({
+      identifier: targetId,
+    })) as any;
+
+    expect(snClient.get).toHaveBeenNthCalledWith(
+      1,
+      "/api/now/table/sys_update_set",
+      {
+        params: {
+          sysparm_query: `sys_id=${targetId}^state=in progress`,
+          sysparm_limit: 1,
+          sysparm_fields: "sys_id,name,state,application,sys_updated_on",
+        },
+      }
+    );
+    expect(snClient.patch).toHaveBeenCalledWith(
+      "/api/now/table/sys_user_preference/pref-1",
+      { value: targetId }
+    );
+    expect(result.success).toBe(true);
+    expect(result.data.current_update_set.sys_id).toBe(targetId);
+  });
+
+  it("creates user preference when none exists", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.get
+      .mockResolvedValueOnce({
+        data: {
+          result: [
+            {
+              sys_id: "fedcba9876543210fedcba9876543210",
+              name: "Unique Update Set",
+              state: "in progress",
+              application: "x_app",
+            },
+          ],
+        },
+        headers: {},
+      })
+      .mockResolvedValueOnce({ data: { result: [] }, headers: {} });
+    snClient.post.mockResolvedValue({ data: { result: {} }, headers: {} });
+
+    await handlers.change_update_set({ identifier: "Unique Update Set" });
+
+    expect(snClient.post).toHaveBeenCalledWith(
+      "/api/now/table/sys_user_preference",
+      {
+        name: "sys_update_set",
+        user: userSysId,
+        value: "fedcba9876543210fedcba9876543210",
+        type: "string",
+      }
+    );
+  });
+
+  it("does not set preference when create_update_set set_as_current is false", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.post.mockResolvedValueOnce({
+      data: {
+        result: {
+          sys_id: "newset1234567890abcdef1234567890ab",
+          name: "New Set",
+          state: "in progress",
+        },
+      },
+      headers: {},
+    });
+
+    const result = (await handlers.create_update_set({
+      name: "New Set",
+      description: "desc",
+      set_as_current: false,
+    })) as any;
+
+    expect(snClient.get).not.toHaveBeenCalled();
+    expect(snClient.patch).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      success: true,
+      data: {
+        update_set: {
+          sys_id: "newset1234567890abcdef1234567890ab",
+          name: "New Set",
+          state: "in progress",
+        },
+        set_as_current: false,
+      },
+    });
+  });
+
+  it("updates existing preference when create_update_set set_as_current is true", async () => {
+    const { handlers, snClient } = setup();
+    const newSetId = "0123456789abcdef0123456789abcdef";
+
+    snClient.post.mockResolvedValueOnce({
+      data: {
+        result: {
+          sys_id: newSetId,
+          name: "Current Set",
+          state: "in progress",
+        },
+      },
+      headers: {},
+    });
+    snClient.get.mockResolvedValueOnce({
+      data: {
+        result: [
+          {
+            sys_id: "pref-99",
+            name: "sys_update_set",
+            user: userSysId,
+            value: "old-value",
+          },
+        ],
+      },
+      headers: {},
+    });
+    snClient.patch.mockResolvedValueOnce({ data: { result: {} }, headers: {} });
+
+    const result = (await handlers.create_update_set({
+      name: "Current Set",
+      set_as_current: true,
+    })) as any;
+
+    expect(snClient.patch).toHaveBeenCalledWith(
+      "/api/now/table/sys_user_preference/pref-99",
+      { value: newSetId }
+    );
+    expect(result.data.set_as_current).toBe(true);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,5 +4,18 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
+    coverage: {
+      provider: "v8",
+      all: true,
+      include: ["src/**/*.ts"],
+      exclude: ["src/servicenow/types.ts", "src/tools/_template.ts"],
+      reporter: ["text", "html", "json-summary"],
+      thresholds: {
+        statements: 57,
+        branches: 82,
+        functions: 92,
+        lines: 57,
+      },
+    },
   },
 });


### PR DESCRIPTION
## Summary
- **71 unit tests** across 14 test files covering auth (OAuth, token refresh), tools (registry, tasks, update sets), middleware (rate limiter), config, server, and ServiceNow client
- **Coverage enforcement**: vitest v8 coverage with thresholds (57% statements/lines, 82% branches, 92% functions), CI updated to run `test:coverage`
- **AI agent instruction files**: CLAUDE.md, AGENTS.md, .github/copilot-instructions.md + alignment check workflow
- **README overhaul**: full documentation with architecture diagram, quick start, tool reference, security guarantees, config table, troubleshooting guide

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — 71/71 tests pass
- [x] CI pipeline runs build + coverage gate successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)