### PR TITLE
Add 6 change request MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Users should have `snc_platform_rest_api_access` for REST API access. Record-lev
 
 ---
 
-## 🧰 Tools (18)
+## 🧰 Tools (24)
 
 ### Incidents
 
@@ -144,6 +144,15 @@ Users should have `snc_platform_rest_api_access` for REST API access. Record-lev
 - `create_incident`
 - `update_incident`
 - `add_work_note`
+
+### Change Requests
+
+- `search_change_requests`
+- `get_change_request`
+- `create_change_request`
+- `update_change_request`
+- `get_change_request_approvals`
+- `add_change_request_work_note`
 
 ### Users and Groups
 
@@ -181,6 +190,8 @@ Server-side protections include:
 
 - `create_incident`: caller identity is server-controlled
 - `update_incident`: protected audit/system fields are stripped
+- `create_change_request`: requester identity is server-controlled
+- `update_change_request`: protected audit/system fields are stripped
 - `submit_catalog_request`: requester identity is server-controlled
 - `approve_or_reject`: approval ownership is verified
 

--- a/src/servicenow/types.ts
+++ b/src/servicenow/types.ts
@@ -88,6 +88,31 @@ export interface CatalogItem extends ServiceNowRecord {
   active: string;
 }
 
+export interface ChangeRequest extends ServiceNowRecord {
+  number: string;
+  short_description: string;
+  description?: string;
+  state: string;
+  type: string;
+  category?: string;
+  priority: string;
+  impact: string;
+  urgency: string;
+  risk: string;
+  assigned_to: string;
+  assignment_group: string;
+  requested_by: string;
+  opened_by: string;
+  start_date?: string;
+  end_date?: string;
+  close_code?: string;
+  close_notes?: string;
+  cmdb_ci?: string;
+  business_service?: string;
+  work_notes?: string;
+  comments?: string;
+}
+
 export interface KnowledgeArticle extends ServiceNowRecord {
   number: string;
   short_description: string;

--- a/src/tools/changeRequests.ts
+++ b/src/tools/changeRequests.ts
@@ -1,0 +1,432 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { ToolContext } from "./registry.js";
+import { buildRecordUrl } from "./registry.js";
+import type {
+  ServiceNowListResponse,
+  ServiceNowSingleResponse,
+  ChangeRequest,
+  Approval,
+} from "../servicenow/types.js";
+import {
+  validateSysId,
+  validateChangeNumber,
+  sanitizeUpdatePayload,
+} from "../utils/validators.js";
+
+type WrapHandler = <T>(
+  handler: (ctx: ToolContext, args: T) => Promise<unknown>
+) => (args: T) => Promise<{
+  content: { type: "text"; text: string }[];
+  isError?: boolean;
+}>;
+
+async function resolveChangeRequestSysId(
+  ctx: ToolContext,
+  identifier: string
+): Promise<
+  | { sysId: string }
+  | { error: { success: false; error: { code: string; message: string } } }
+> {
+  if (validateChangeNumber(identifier)) {
+    const { data: lookupData } = await ctx.snClient.get<
+      ServiceNowListResponse<ChangeRequest>
+    >("/api/now/table/change_request", {
+      params: {
+        sysparm_query: `number=${identifier}`,
+        sysparm_limit: 1,
+        sysparm_fields: "sys_id",
+      },
+    });
+    if (!lookupData.result.length) {
+      return {
+        error: {
+          success: false,
+          error: {
+            code: "NOT_FOUND",
+            message: `No change request found: ${identifier}`,
+          },
+        },
+      };
+    }
+    return { sysId: lookupData.result[0].sys_id };
+  } else if (validateSysId(identifier)) {
+    return { sysId: identifier };
+  } else {
+    return {
+      error: {
+        success: false,
+        error: {
+          code: "VALIDATION_ERROR",
+          message:
+            "Invalid identifier. Provide a change number (CHG...) or a 32-character sys_id.",
+        },
+      },
+    };
+  }
+}
+
+export function registerChangeRequestTools(
+  server: McpServer,
+  wrapHandler: WrapHandler
+): void {
+  // search_change_requests
+  server.tool(
+    "search_change_requests",
+    "Search for change requests with various filters. Returns a paginated summary list.",
+    {
+      query: z
+        .string()
+        .optional()
+        .describe("Free-text search in short description"),
+      state: z
+        .string()
+        .optional()
+        .describe("Filter by state (e.g. 'New', 'Assess', 'Implement', 'Review', 'Closed')"),
+      type: z
+        .string()
+        .optional()
+        .describe("Filter by type (Normal, Standard, Emergency)"),
+      priority: z
+        .string()
+        .optional()
+        .describe("Filter by priority (1-5)"),
+      assigned_to_me: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe("Only show change requests assigned to me"),
+      assignment_group: z
+        .string()
+        .optional()
+        .describe("Filter by assignment group name"),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .default(10)
+        .describe("Maximum results"),
+      offset: z.number().int().min(0).default(0).describe("Result offset for pagination"),
+    },
+    wrapHandler(
+      async (
+        ctx: ToolContext,
+        args: {
+          query?: string;
+          state?: string;
+          type?: string;
+          priority?: string;
+          assigned_to_me?: boolean;
+          assignment_group?: string;
+          limit: number;
+          offset: number;
+        }
+      ) => {
+        const queryParts: string[] = [];
+
+        if (args.query) {
+          queryParts.push(`short_descriptionLIKE${args.query}`);
+        }
+        if (args.state) {
+          queryParts.push(`state=${args.state}`);
+        }
+        if (args.type) {
+          queryParts.push(`type=${args.type}`);
+        }
+        if (args.priority) {
+          queryParts.push(`priority=${args.priority}`);
+        }
+        if (args.assigned_to_me) {
+          queryParts.push(`assigned_to=${ctx.userSysId}`);
+        }
+        if (args.assignment_group) {
+          queryParts.push(`assignment_groupLIKE${args.assignment_group}`);
+        }
+
+        queryParts.push("ORDERBYDESCsys_updated_on");
+
+        const { data, headers } = await ctx.snClient.get<
+          ServiceNowListResponse<ChangeRequest>
+        >("/api/now/table/change_request", {
+          params: {
+            sysparm_query: queryParts.join("^"),
+            sysparm_limit: args.limit,
+            sysparm_offset: args.offset,
+            sysparm_fields:
+              "sys_id,number,short_description,state,type,priority,impact,urgency,risk,assigned_to,assignment_group,requested_by,category,start_date,end_date,sys_updated_on",
+          },
+        });
+
+        return {
+          success: true,
+          data: data.result.map((r) => ({
+            ...r,
+            self_link: buildRecordUrl(ctx.instanceUrl, "change_request", r.sys_id),
+          })),
+          metadata: {
+            total_count: parseInt(headers["x-total-count"] || "0", 10),
+            returned_count: data.result.length,
+            offset: args.offset,
+          },
+        };
+      }
+    )
+  );
+
+  // get_change_request
+  server.tool(
+    "get_change_request",
+    "Get full details of a specific change request by change number (CHG...) or sys_id.",
+    {
+      identifier: z
+        .string()
+        .describe("Change number (e.g. CHG0012345) or sys_id"),
+    },
+    wrapHandler(async (ctx: ToolContext, args: { identifier: string }) => {
+      let path: string;
+      let params: Record<string, string | number | boolean> = {};
+
+      if (validateChangeNumber(args.identifier)) {
+        path = "/api/now/table/change_request";
+        params = {
+          sysparm_query: `number=${args.identifier}`,
+          sysparm_limit: 1,
+        };
+      } else if (validateSysId(args.identifier)) {
+        path = `/api/now/table/change_request/${args.identifier}`;
+      } else {
+        return {
+          success: false,
+          error: {
+            code: "VALIDATION_ERROR",
+            message:
+              "Invalid identifier. Provide a change number (CHG...) or a 32-character sys_id.",
+          },
+        };
+      }
+
+      const { data } = await ctx.snClient.get<
+        ServiceNowSingleResponse<ChangeRequest> | ServiceNowListResponse<ChangeRequest>
+      >(path, { params });
+
+      const result = "result" in data
+        ? Array.isArray(data.result)
+          ? data.result[0]
+          : data.result
+        : null;
+
+      if (!result) {
+        return {
+          success: false,
+          error: {
+            code: "NOT_FOUND",
+            message: `No change request found with identifier: ${args.identifier}`,
+          },
+        };
+      }
+
+      return {
+        success: true,
+        data: {
+          ...result,
+          self_link: buildRecordUrl(ctx.instanceUrl, "change_request", result.sys_id),
+        },
+      };
+    })
+  );
+
+  // create_change_request
+  server.tool(
+    "create_change_request",
+    "Create a new change request in ServiceNow. Requires at least a short description.",
+    {
+      short_description: z.string().min(1).describe("Brief summary of the change"),
+      description: z.string().optional().describe("Detailed description"),
+      type: z.string().optional().describe("Change type (Normal, Standard, Emergency)"),
+      impact: z.number().int().min(1).max(3).optional().describe("Impact (1=High, 2=Medium, 3=Low)"),
+      urgency: z.number().int().min(1).max(3).optional().describe("Urgency (1=High, 2=Medium, 3=Low)"),
+      category: z.string().optional().describe("Change category"),
+      assignment_group: z.string().optional().describe("Assignment group name or sys_id"),
+      cmdb_ci: z.string().optional().describe("Configuration item name or sys_id"),
+      start_date: z.string().optional().describe("Planned start date (ISO 8601)"),
+      end_date: z.string().optional().describe("Planned end date (ISO 8601)"),
+    },
+    wrapHandler(
+      async (
+        ctx: ToolContext,
+        args: {
+          short_description: string;
+          description?: string;
+          type?: string;
+          impact?: number;
+          urgency?: number;
+          category?: string;
+          assignment_group?: string;
+          cmdb_ci?: string;
+          start_date?: string;
+          end_date?: string;
+        }
+      ) => {
+        const body: Record<string, unknown> = {
+          short_description: args.short_description,
+          requested_by: ctx.userSysId,
+        };
+
+        if (args.description) body.description = args.description;
+        if (args.type) body.type = args.type;
+        if (args.impact) body.impact = args.impact;
+        if (args.urgency) body.urgency = args.urgency;
+        if (args.category) body.category = args.category;
+        if (args.assignment_group) body.assignment_group = args.assignment_group;
+        if (args.cmdb_ci) body.cmdb_ci = args.cmdb_ci;
+        if (args.start_date) body.start_date = args.start_date;
+        if (args.end_date) body.end_date = args.end_date;
+
+        // Calculate priority from impact + urgency
+        if (args.impact && args.urgency) {
+          body.priority = args.impact + args.urgency - 1;
+        }
+
+        const { data } = await ctx.snClient.post<
+          ServiceNowSingleResponse<ChangeRequest>
+        >("/api/now/table/change_request", body);
+
+        return {
+          success: true,
+          data: {
+            ...data.result,
+            self_link: buildRecordUrl(ctx.instanceUrl, "change_request", data.result.sys_id),
+          },
+        };
+      }
+    )
+  );
+
+  // update_change_request
+  server.tool(
+    "update_change_request",
+    "Update fields on an existing change request. Provide the change number or sys_id and the fields to update.",
+    {
+      identifier: z
+        .string()
+        .describe("Change number (CHG...) or sys_id"),
+      fields: z
+        .record(z.unknown())
+        .describe(
+          "Fields to update (e.g. { state: 'Implement', assignment_group: 'CAB' })"
+        ),
+    },
+    wrapHandler(
+      async (
+        ctx: ToolContext,
+        args: { identifier: string; fields: Record<string, unknown> }
+      ) => {
+        const resolved = await resolveChangeRequestSysId(ctx, args.identifier);
+        if ("error" in resolved) return resolved.error;
+
+        const sanitized = sanitizeUpdatePayload(args.fields);
+
+        const { data } = await ctx.snClient.patch<
+          ServiceNowSingleResponse<ChangeRequest>
+        >(`/api/now/table/change_request/${resolved.sysId}`, sanitized);
+
+        return {
+          success: true,
+          data: {
+            ...data.result,
+            self_link: buildRecordUrl(ctx.instanceUrl, "change_request", data.result.sys_id),
+          },
+        };
+      }
+    )
+  );
+
+  // get_change_request_approvals
+  server.tool(
+    "get_change_request_approvals",
+    "Get approval records linked to a change request.",
+    {
+      identifier: z
+        .string()
+        .describe("Change number (CHG...) or sys_id"),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .default(20)
+        .describe("Maximum results"),
+    },
+    wrapHandler(
+      async (
+        ctx: ToolContext,
+        args: { identifier: string; limit: number }
+      ) => {
+        const resolved = await resolveChangeRequestSysId(ctx, args.identifier);
+        if ("error" in resolved) return resolved.error;
+
+        const { data } = await ctx.snClient.get<
+          ServiceNowListResponse<Approval>
+        >("/api/now/table/sysapproval_approver", {
+          params: {
+            sysparm_query: `sysapproval=${resolved.sysId}`,
+            sysparm_limit: args.limit,
+            sysparm_fields:
+              "sys_id,state,approver,sysapproval,source_table,comments,due_date,sys_created_on,sys_updated_on",
+          },
+        });
+
+        return {
+          success: true,
+          data: data.result,
+          metadata: {
+            change_request_sys_id: resolved.sysId,
+            returned_count: data.result.length,
+          },
+        };
+      }
+    )
+  );
+
+  // add_change_request_work_note
+  server.tool(
+    "add_change_request_work_note",
+    "Add a work note (internal) or comment (customer-visible) to a change request.",
+    {
+      identifier: z
+        .string()
+        .describe("Change number (CHG...) or sys_id"),
+      note: z.string().min(1).describe("The note text to add"),
+      type: z
+        .enum(["work_note", "comment"])
+        .default("work_note")
+        .describe("work_note = internal, comment = customer-visible"),
+    },
+    wrapHandler(
+      async (
+        ctx: ToolContext,
+        args: { identifier: string; note: string; type: "work_note" | "comment" }
+      ) => {
+        const resolved = await resolveChangeRequestSysId(ctx, args.identifier);
+        if ("error" in resolved) return resolved.error;
+
+        const field =
+          args.type === "work_note" ? "work_notes" : "comments";
+
+        const { data } = await ctx.snClient.patch<
+          ServiceNowSingleResponse<ChangeRequest>
+        >(`/api/now/table/change_request/${resolved.sysId}`, { [field]: args.note });
+
+        return {
+          success: true,
+          data: {
+            sys_id: resolved.sysId,
+            self_link: buildRecordUrl(ctx.instanceUrl, "change_request", resolved.sysId),
+            message: `${args.type === "work_note" ? "Work note" : "Comment"} added successfully`,
+          },
+        };
+      }
+    )
+  );
+}

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -13,6 +13,7 @@ import { registerKnowledgeTools } from "./knowledge.js";
 import { registerTaskTools } from "./tasks.js";
 import { registerCatalogTools } from "./catalog.js";
 import { registerUpdateSetTools } from "./updateSets.js";
+import { registerChangeRequestTools } from "./changeRequests.js";
 
 export interface ToolContext {
   snClient: ServiceNowClient;
@@ -135,6 +136,7 @@ export function registerAllTools(
   registerTaskTools(server, wrapHandler);
   registerCatalogTools(server, wrapHandler);
   registerUpdateSetTools(server, wrapHandler);
+  registerChangeRequestTools(server, wrapHandler);
 
   logger.info("All tools registered");
 }

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -1,5 +1,6 @@
 const SYS_ID_REGEX = /^[0-9a-fA-F]{32}$/;
 const INCIDENT_NUMBER_REGEX = /^INC\d{7,}$/;
+const CHANGE_NUMBER_REGEX = /^CHG\d{7,}$/;
 
 export function validateSysId(value: string): boolean {
   return SYS_ID_REGEX.test(value);
@@ -7,6 +8,10 @@ export function validateSysId(value: string): boolean {
 
 export function validateIncidentNumber(value: string): boolean {
   return INCIDENT_NUMBER_REGEX.test(value);
+}
+
+export function validateChangeNumber(value: string): boolean {
+  return CHANGE_NUMBER_REGEX.test(value);
 }
 
 export function validateState(state: string): boolean {

--- a/tests/unit/tools/changeRequests.test.ts
+++ b/tests/unit/tools/changeRequests.test.ts
@@ -1,0 +1,520 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerChangeRequestTools } from "../../../src/tools/changeRequests.js";
+import type { ToolContext } from "../../../src/tools/registry.js";
+
+type WrappedHandler<T = unknown> = (args: T) => Promise<unknown>;
+
+describe("registerChangeRequestTools", () => {
+  const userSysId = "abc123def456abc123def456abc12345";
+
+  function setup() {
+    const handlers: Record<string, WrappedHandler> = {};
+
+    const server = {
+      tool: vi.fn(
+        (
+          name: string,
+          _description: string,
+          _schema: unknown,
+          handler: WrappedHandler
+        ) => {
+          handlers[name] = handler;
+        }
+      ),
+    };
+
+    const snClient = {
+      get: vi.fn(),
+      patch: vi.fn(),
+      post: vi.fn(),
+    };
+
+    const ctx: ToolContext = {
+      snClient: snClient as unknown as ToolContext["snClient"],
+      instanceUrl: "https://example.service-now.com",
+      userSysId,
+      userName: "john.doe",
+      displayName: "John Doe",
+    };
+
+    const wrapHandler = <T>(
+      handler: (context: ToolContext, args: T) => Promise<unknown>
+    ) => {
+      return async (args: T) => handler(ctx, args);
+    };
+
+    registerChangeRequestTools(server as any, wrapHandler);
+
+    return { handlers, snClient, server };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // --- search_change_requests ---
+
+  it("search_change_requests returns results with self_link", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.get.mockResolvedValue({
+      data: {
+        result: [
+          { sys_id: "chg-sys-id-001", number: "CHG0010001", short_description: "Deploy patch" },
+        ],
+      },
+      headers: { "x-total-count": "1" },
+    });
+
+    const result = (await handlers.search_change_requests({
+      query: "Deploy",
+      limit: 10,
+      offset: 0,
+    })) as any;
+
+    expect(snClient.get).toHaveBeenCalledWith("/api/now/table/change_request", {
+      params: {
+        sysparm_query: "short_descriptionLIKEDeploy^ORDERBYDESCsys_updated_on",
+        sysparm_limit: 10,
+        sysparm_offset: 0,
+        sysparm_fields:
+          "sys_id,number,short_description,state,type,priority,impact,urgency,risk,assigned_to,assignment_group,requested_by,category,start_date,end_date,sys_updated_on",
+      },
+    });
+    expect(result.success).toBe(true);
+    expect(result.data[0].self_link).toBe(
+      "https://example.service-now.com/change_request.do?sys_id=chg-sys-id-001"
+    );
+    expect(result.metadata).toEqual({
+      total_count: 1,
+      returned_count: 1,
+      offset: 0,
+    });
+  });
+
+  it("search_change_requests builds query with all filter options", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.get.mockResolvedValue({
+      data: { result: [] },
+      headers: { "x-total-count": "0" },
+    });
+
+    await handlers.search_change_requests({
+      query: "Network",
+      state: "Implement",
+      type: "Emergency",
+      priority: "1",
+      assigned_to_me: true,
+      assignment_group: "CAB",
+      limit: 5,
+      offset: 10,
+    });
+
+    const call = snClient.get.mock.calls[0];
+    const query = call[1].params.sysparm_query;
+    expect(query).toContain("short_descriptionLIKENetwork");
+    expect(query).toContain("state=Implement");
+    expect(query).toContain("type=Emergency");
+    expect(query).toContain("priority=1");
+    expect(query).toContain(`assigned_to=${userSysId}`);
+    expect(query).toContain("assignment_groupLIKECAB");
+  });
+
+  // --- get_change_request ---
+
+  it("get_change_request resolves by CHG number and returns self_link", async () => {
+    const { handlers, snClient } = setup();
+    const chgSysId = "0123456789abcdef0123456789abcdef";
+
+    snClient.get.mockResolvedValue({
+      data: {
+        result: [
+          { sys_id: chgSysId, number: "CHG0012345", short_description: "Server upgrade" },
+        ],
+      },
+      headers: {},
+    });
+
+    const result = (await handlers.get_change_request({
+      identifier: "CHG0012345",
+    })) as any;
+
+    expect(snClient.get).toHaveBeenCalledWith("/api/now/table/change_request", {
+      params: {
+        sysparm_query: "number=CHG0012345",
+        sysparm_limit: 1,
+      },
+    });
+    expect(result.success).toBe(true);
+    expect(result.data.self_link).toBe(
+      `https://example.service-now.com/change_request.do?sys_id=${chgSysId}`
+    );
+  });
+
+  it("get_change_request resolves by sys_id directly", async () => {
+    const { handlers, snClient } = setup();
+    const sysId = "0123456789abcdef0123456789abcdef";
+
+    snClient.get.mockResolvedValue({
+      data: { result: { sys_id: sysId, number: "CHG0010001" } },
+      headers: {},
+    });
+
+    const result = (await handlers.get_change_request({ identifier: sysId })) as any;
+
+    expect(snClient.get).toHaveBeenCalledWith(
+      `/api/now/table/change_request/${sysId}`,
+      { params: {} }
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("get_change_request returns VALIDATION_ERROR for invalid identifier", async () => {
+    const { handlers, snClient } = setup();
+
+    const result = (await handlers.get_change_request({
+      identifier: "bad-id",
+    })) as any;
+
+    expect(result).toEqual({
+      success: false,
+      error: {
+        code: "VALIDATION_ERROR",
+        message:
+          "Invalid identifier. Provide a change number (CHG...) or a 32-character sys_id.",
+      },
+    });
+    expect(snClient.get).not.toHaveBeenCalled();
+  });
+
+  it("get_change_request returns NOT_FOUND when no match", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.get.mockResolvedValue({
+      data: { result: [] },
+      headers: {},
+    });
+
+    const result = (await handlers.get_change_request({ identifier: "CHG9999999" })) as any;
+    expect(result.success).toBe(false);
+    expect(result.error.code).toBe("NOT_FOUND");
+  });
+
+  // --- create_change_request ---
+
+  it("create_change_request sets requested_by to ctx.userSysId and returns self_link", async () => {
+    const { handlers, snClient } = setup();
+    const newSysId = "fedcba9876543210fedcba9876543210";
+
+    snClient.post.mockResolvedValue({
+      data: {
+        result: {
+          sys_id: newSysId,
+          number: "CHG0099999",
+          short_description: "New change",
+          requested_by: userSysId,
+        },
+      },
+      headers: {},
+    });
+
+    const result = (await handlers.create_change_request({
+      short_description: "New change",
+      impact: 2,
+      urgency: 2,
+    })) as any;
+
+    expect(snClient.post).toHaveBeenCalledWith("/api/now/table/change_request", {
+      short_description: "New change",
+      requested_by: userSysId,
+      impact: 2,
+      urgency: 2,
+      priority: 3,
+    });
+    expect(result.success).toBe(true);
+    expect(result.data.self_link).toBe(
+      `https://example.service-now.com/change_request.do?sys_id=${newSysId}`
+    );
+  });
+
+  it("create_change_request includes optional fields and computes priority", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.post.mockResolvedValue({
+      data: { result: { sys_id: "0123456789abcdef0123456789abcdef" } },
+      headers: {},
+    });
+
+    await handlers.create_change_request({
+      short_description: "Test",
+      description: "Full details",
+      type: "Emergency",
+      impact: 1,
+      urgency: 2,
+      category: "Hardware",
+      assignment_group: "CAB",
+      cmdb_ci: "App Server",
+      start_date: "2026-04-01T08:00:00Z",
+      end_date: "2026-04-01T12:00:00Z",
+    });
+
+    const body = snClient.post.mock.calls[0][1];
+    expect(body.description).toBe("Full details");
+    expect(body.type).toBe("Emergency");
+    expect(body.category).toBe("Hardware");
+    expect(body.assignment_group).toBe("CAB");
+    expect(body.cmdb_ci).toBe("App Server");
+    expect(body.start_date).toBe("2026-04-01T08:00:00Z");
+    expect(body.end_date).toBe("2026-04-01T12:00:00Z");
+    expect(body.priority).toBe(2);
+  });
+
+  // --- update_change_request ---
+
+  it("update_change_request resolves number then patches and returns self_link", async () => {
+    const { handlers, snClient } = setup();
+    const chgSysId = "aabbccddaabbccddaabbccddaabbccdd";
+
+    // Number lookup
+    snClient.get.mockResolvedValueOnce({
+      data: { result: [{ sys_id: chgSysId }] },
+      headers: {},
+    });
+
+    // Patch
+    snClient.patch.mockResolvedValue({
+      data: {
+        result: {
+          sys_id: chgSysId,
+          number: "CHG0010001",
+          state: "Implement",
+        },
+      },
+      headers: {},
+    });
+
+    const result = (await handlers.update_change_request({
+      identifier: "CHG0010001",
+      fields: { state: "Implement" },
+    })) as any;
+
+    expect(snClient.get).toHaveBeenCalledWith("/api/now/table/change_request", {
+      params: {
+        sysparm_query: "number=CHG0010001",
+        sysparm_limit: 1,
+        sysparm_fields: "sys_id",
+      },
+    });
+    expect(snClient.patch).toHaveBeenCalledWith(
+      `/api/now/table/change_request/${chgSysId}`,
+      { state: "Implement" }
+    );
+    expect(result.success).toBe(true);
+    expect(result.data.self_link).toBe(
+      `https://example.service-now.com/change_request.do?sys_id=${chgSysId}`
+    );
+  });
+
+  it("update_change_request returns VALIDATION_ERROR for invalid identifier", async () => {
+    const { handlers } = setup();
+
+    const result = (await handlers.update_change_request({
+      identifier: "bad",
+      fields: { state: "Closed" },
+    })) as any;
+
+    expect(result.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("update_change_request returns NOT_FOUND when number lookup fails", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.get.mockResolvedValue({ data: { result: [] }, headers: {} });
+
+    const result = (await handlers.update_change_request({
+      identifier: "CHG0099999",
+      fields: { state: "Closed" },
+    })) as any;
+
+    expect(result.error.code).toBe("NOT_FOUND");
+  });
+
+  it("update_change_request strips readonly fields via sanitizeUpdatePayload", async () => {
+    const { handlers, snClient } = setup();
+    const sysId = "0123456789abcdef0123456789abcdef";
+
+    snClient.patch.mockResolvedValue({
+      data: { result: { sys_id: sysId, state: "Review" } },
+      headers: {},
+    });
+
+    await handlers.update_change_request({
+      identifier: sysId,
+      fields: { state: "Review", sys_id: "hacked", number: "CHG000", opened_by: "someone" },
+    });
+
+    expect(snClient.patch).toHaveBeenCalledWith(
+      `/api/now/table/change_request/${sysId}`,
+      { state: "Review" }
+    );
+  });
+
+  // --- get_change_request_approvals ---
+
+  it("get_change_request_approvals returns linked approvals", async () => {
+    const { handlers, snClient } = setup();
+    const chgSysId = "0123456789abcdef0123456789abcdef";
+
+    snClient.get.mockResolvedValue({
+      data: {
+        result: [
+          { sys_id: "appr-001", state: "approved", approver: "mgr-001", sysapproval: chgSysId },
+        ],
+      },
+      headers: {},
+    });
+
+    const result = (await handlers.get_change_request_approvals({
+      identifier: chgSysId,
+      limit: 20,
+    })) as any;
+
+    expect(snClient.get).toHaveBeenCalledWith("/api/now/table/sysapproval_approver", {
+      params: {
+        sysparm_query: `sysapproval=${chgSysId}`,
+        sysparm_limit: 20,
+        sysparm_fields:
+          "sys_id,state,approver,sysapproval,source_table,comments,due_date,sys_created_on,sys_updated_on",
+      },
+    });
+    expect(result.success).toBe(true);
+    expect(result.data).toHaveLength(1);
+    expect(result.metadata.change_request_sys_id).toBe(chgSysId);
+  });
+
+  it("get_change_request_approvals resolves CHG number", async () => {
+    const { handlers, snClient } = setup();
+    const chgSysId = "aabbccddaabbccddaabbccddaabbccdd";
+
+    // Number lookup
+    snClient.get.mockResolvedValueOnce({
+      data: { result: [{ sys_id: chgSysId }] },
+      headers: {},
+    });
+
+    // Approvals query
+    snClient.get.mockResolvedValueOnce({
+      data: { result: [] },
+      headers: {},
+    });
+
+    const result = (await handlers.get_change_request_approvals({
+      identifier: "CHG0010001",
+      limit: 20,
+    })) as any;
+
+    expect(snClient.get).toHaveBeenCalledTimes(2);
+    expect(result.success).toBe(true);
+    expect(result.metadata.change_request_sys_id).toBe(chgSysId);
+  });
+
+  it("get_change_request_approvals returns NOT_FOUND for unknown CHG", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.get.mockResolvedValue({ data: { result: [] }, headers: {} });
+
+    const result = (await handlers.get_change_request_approvals({
+      identifier: "CHG9999999",
+      limit: 20,
+    })) as any;
+
+    expect(result.success).toBe(false);
+    expect(result.error.code).toBe("NOT_FOUND");
+  });
+
+  // --- add_change_request_work_note ---
+
+  it("add_change_request_work_note uses work_notes field for work_note type", async () => {
+    const { handlers, snClient } = setup();
+    const chgSysId = "11223344556677881122334455667788";
+
+    // Number lookup
+    snClient.get.mockResolvedValueOnce({
+      data: { result: [{ sys_id: chgSysId }] },
+      headers: {},
+    });
+
+    // Patch
+    snClient.patch.mockResolvedValue({
+      data: {
+        result: { sys_id: chgSysId, work_notes: "Investigating now" },
+      },
+      headers: {},
+    });
+
+    const result = (await handlers.add_change_request_work_note({
+      identifier: "CHG0010002",
+      note: "Investigating now",
+      type: "work_note",
+    })) as any;
+
+    expect(snClient.patch).toHaveBeenCalledWith(
+      `/api/now/table/change_request/${chgSysId}`,
+      { work_notes: "Investigating now" }
+    );
+    expect(result.success).toBe(true);
+    expect(result.data.self_link).toBe(
+      `https://example.service-now.com/change_request.do?sys_id=${chgSysId}`
+    );
+    expect(result.data.message).toBe("Work note added successfully");
+  });
+
+  it("add_change_request_work_note uses comments field for comment type", async () => {
+    const { handlers, snClient } = setup();
+    const sysId = "0123456789abcdef0123456789abcdef";
+
+    snClient.patch.mockResolvedValue({
+      data: { result: { sys_id: sysId } },
+      headers: {},
+    });
+
+    const result = (await handlers.add_change_request_work_note({
+      identifier: sysId,
+      note: "Customer update",
+      type: "comment",
+    })) as any;
+
+    expect(snClient.patch).toHaveBeenCalledWith(
+      `/api/now/table/change_request/${sysId}`,
+      { comments: "Customer update" }
+    );
+    expect(result.data.message).toBe("Comment added successfully");
+  });
+
+  it("add_change_request_work_note returns VALIDATION_ERROR for invalid identifier", async () => {
+    const { handlers } = setup();
+
+    const result = (await handlers.add_change_request_work_note({
+      identifier: "bad",
+      note: "test",
+      type: "work_note",
+    })) as any;
+
+    expect(result.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("add_change_request_work_note returns NOT_FOUND when number lookup fails", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.get.mockResolvedValue({ data: { result: [] }, headers: {} });
+
+    const result = (await handlers.add_change_request_work_note({
+      identifier: "CHG9999999",
+      note: "test",
+      type: "work_note",
+    })) as any;
+
+    expect(result.error.code).toBe("NOT_FOUND");
+  });
+});

--- a/tests/unit/tools/registry.test.ts
+++ b/tests/unit/tools/registry.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   registerTaskTools: vi.fn(),
   registerCatalogTools: vi.fn(),
   registerUpdateSetTools: vi.fn(),
+  registerChangeRequestTools: vi.fn(),
   checkLimit: vi.fn(),
   ensureFreshToken: vi.fn(),
   createToolError: vi.fn(),
@@ -38,6 +39,10 @@ vi.mock("../../../src/tools/catalog.js", () => ({
 
 vi.mock("../../../src/tools/updateSets.js", () => ({
   registerUpdateSetTools: mocks.registerUpdateSetTools,
+}));
+
+vi.mock("../../../src/tools/changeRequests.js", () => ({
+  registerChangeRequestTools: mocks.registerChangeRequestTools,
 }));
 
 vi.mock("../../../src/middleware/rateLimiter.js", () => ({
@@ -126,6 +131,7 @@ describe("registerAllTools", () => {
     mocks.registerTaskTools.mockImplementation(() => {});
     mocks.registerCatalogTools.mockImplementation(() => {});
     mocks.registerUpdateSetTools.mockImplementation(() => {});
+    mocks.registerChangeRequestTools.mockImplementation(() => {});
 
     mocks.checkLimit.mockResolvedValue(true);
     mocks.ensureFreshToken.mockResolvedValue(resolvedToken);


### PR DESCRIPTION
## Summary
- Add 6 change request tools (`search_change_requests`, `get_change_request`, `create_change_request`, `update_change_request`, `get_change_request_approvals`, `add_change_request_work_note`) mirroring incident tool patterns
- Add `ChangeRequest` type, `validateChangeNumber()` validator, and registry wiring
- Add 19 unit tests covering all tools including validation, not-found, and resolution paths

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — all 153 tests pass (19 new)
- [x] Existing tests unaffected (registry test mock updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)