### PR TITLE
Update docs for priority and READONLY_FIELDS changes

### DIFF
--- a/docs/security/input-validation.md
+++ b/docs/security/input-validation.md
@@ -51,10 +51,6 @@ Validates against allowed incident states:
 - String values: `New`, `In Progress`, `On Hold`, `Resolved`, `Closed`, `Canceled`
 - Numeric equivalents: `1`, `2`, `3`, `6`, `7`, `8`
 
-### `validatePriority(impact: number, urgency: number): number`
-
-Validates impact and urgency are between 1 and 3, calculates priority as `impact + urgency - 1`.
-
 ## Payload Sanitization
 
 ### `sanitizeUpdatePayload(payload): Record<string, unknown>`
@@ -75,6 +71,9 @@ const READONLY_FIELDS = new Set([
   "number",
   "opened_at",
   "opened_by",
+  "caller_id",
+  "requested_by",
+  "priority",
 ]);
 ```
 

--- a/docs/tools/incidents.md
+++ b/docs/tools/incidents.md
@@ -47,7 +47,7 @@ Create a new incident. The `caller_id` is automatically set to the authenticated
 
 **Identity enforcement**: `caller_id` is always set to `ctx.userSysId`. See [Identity Enforcement](../security/identity-enforcement.md).
 
-**Priority calculation**: If both `impact` and `urgency` are provided, priority is calculated as `impact + urgency - 1`.
+**Priority**: Calculated automatically by ServiceNow from impact and urgency via its native priority lookup rules.
 
 ## `update_incident`
 


### PR DESCRIPTION
## Summary

- Remove stale `validatePriority` reference from input-validation docs (function was deleted)
- Update `READONLY_FIELDS` list in docs to include `caller_id`, `requested_by`, `priority`
- Update `create_incident` docs: priority is now calculated by ServiceNow, not the server

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — all 208 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)