### PR TITLE
Fix encoded query injection via unescaped string interpolation

### DIFF
--- a/src/servicenow/queryBuilder.ts
+++ b/src/servicenow/queryBuilder.ts
@@ -17,7 +17,7 @@ export function validateFieldName(field: string): boolean {
   return FIELD_NAME_REGEX.test(field);
 }
 
-function sanitizeValue(value: string): string {
+export function sanitizeValue(value: string): string {
   // Escape characters that have special meaning in encoded queries
   return value
     .replace(/\\/g, "\\\\")

--- a/src/tools/changeRequests.ts
+++ b/src/tools/changeRequests.ts
@@ -13,6 +13,7 @@ import {
   validateChangeNumber,
   sanitizeUpdatePayload,
 } from "../utils/validators.js";
+import { sanitizeValue } from "../servicenow/queryBuilder.js";
 import { paginateAll } from "../servicenow/paginator.js";
 
 type WrapHandler = <T>(
@@ -127,22 +128,22 @@ export function registerChangeRequestTools(
         const queryParts: string[] = [];
 
         if (args.query) {
-          queryParts.push(`short_descriptionLIKE${args.query}`);
+          queryParts.push(`short_descriptionLIKE${sanitizeValue(args.query)}`);
         }
         if (args.state) {
-          queryParts.push(`state=${args.state}`);
+          queryParts.push(`state=${sanitizeValue(args.state)}`);
         }
         if (args.type) {
-          queryParts.push(`type=${args.type}`);
+          queryParts.push(`type=${sanitizeValue(args.type)}`);
         }
         if (args.priority) {
-          queryParts.push(`priority=${args.priority}`);
+          queryParts.push(`priority=${sanitizeValue(args.priority)}`);
         }
         if (args.assigned_to_me) {
           queryParts.push(`assigned_to=${ctx.userSysId}`);
         }
         if (args.assignment_group) {
-          queryParts.push(`assignment_groupLIKE${args.assignment_group}`);
+          queryParts.push(`assignment_groupLIKE${sanitizeValue(args.assignment_group)}`);
         }
 
         queryParts.push("ORDERBYDESCsys_updated_on");

--- a/src/tools/incidents.ts
+++ b/src/tools/incidents.ts
@@ -12,6 +12,7 @@ import {
   validateIncidentNumber,
   sanitizeUpdatePayload,
 } from "../utils/validators.js";
+import { sanitizeValue } from "../servicenow/queryBuilder.js";
 
 type WrapHandler = <T>(
   handler: (ctx: ToolContext, args: T) => Promise<unknown>
@@ -75,19 +76,19 @@ export function registerIncidentTools(
         const queryParts: string[] = [];
 
         if (args.query) {
-          queryParts.push(`short_descriptionLIKE${args.query}`);
+          queryParts.push(`short_descriptionLIKE${sanitizeValue(args.query)}`);
         }
         if (args.state) {
-          queryParts.push(`state=${args.state}`);
+          queryParts.push(`state=${sanitizeValue(args.state)}`);
         }
         if (args.priority) {
-          queryParts.push(`priority=${args.priority}`);
+          queryParts.push(`priority=${sanitizeValue(args.priority)}`);
         }
         if (args.assigned_to_me) {
           queryParts.push(`assigned_to=${ctx.userSysId}`);
         }
         if (args.assignment_group) {
-          queryParts.push(`assignment_groupLIKE${args.assignment_group}`);
+          queryParts.push(`assignment_groupLIKE${sanitizeValue(args.assignment_group)}`);
         }
 
         queryParts.push("ORDERBYDESCsys_updated_on");

--- a/src/tools/users.ts
+++ b/src/tools/users.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import type { ToolContext } from "./registry.js";
 import { buildRecordUrl } from "./registry.js";
 import type { ServiceNowListResponse, ServiceNowSingleResponse, User, Group } from "../servicenow/types.js";
-import { buildEncodedQuery, type QueryFilter } from "../servicenow/queryBuilder.js";
+import { sanitizeValue } from "../servicenow/queryBuilder.js";
 
 type WrapHandler = <T>(
   handler: (ctx: ToolContext, args: T) => Promise<unknown>
@@ -22,8 +22,7 @@ export function registerUserTools(
       limit: z.number().int().min(1).max(50).default(10).describe("Maximum results to return"),
     },
     wrapHandler(async (ctx: ToolContext, args: { query: string; limit: number }) => {
-      const filters: QueryFilter[] = [];
-      const q = args.query;
+      const q = sanitizeValue(args.query);
 
       // Build OR query for name, email, employee_number
       const encodedQuery = `nameLIKE${q}^ORemail=${q}^ORemployee_number=${q}^ORuser_name=${q}`;
@@ -66,7 +65,7 @@ export function registerUserTools(
         "/api/now/table/sys_user_group",
         {
           params: {
-            sysparm_query: `nameLIKE${args.query}^active=true`,
+            sysparm_query: `nameLIKE${sanitizeValue(args.query)}^active=true`,
             sysparm_limit: args.limit,
             sysparm_fields: "sys_id,name,description,manager,email,active,type",
           },

--- a/tests/unit/servicenow/queryBuilder.test.ts
+++ b/tests/unit/servicenow/queryBuilder.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   buildEncodedQuery,
   buildSimpleQuery,
+  sanitizeValue,
   validateFieldName,
   type QueryFilter,
 } from "../../../src/servicenow/queryBuilder.js";
@@ -67,6 +68,28 @@ describe("queryBuilder", () => {
       ];
 
       expect(() => buildEncodedQuery(filters)).toThrow("Invalid field name");
+    });
+  });
+
+  describe("sanitizeValue", () => {
+    it("should escape carets", () => {
+      expect(sanitizeValue("test^value")).toBe("test\\^value");
+    });
+
+    it("should escape commas", () => {
+      expect(sanitizeValue("a,b")).toBe("a\\,b");
+    });
+
+    it("should escape backslashes", () => {
+      expect(sanitizeValue("path\\to")).toBe("path\\\\to");
+    });
+
+    it("should escape multiple special characters", () => {
+      expect(sanitizeValue("a^b,c\\d")).toBe("a\\^b\\,c\\\\d");
+    });
+
+    it("should return plain strings unchanged", () => {
+      expect(sanitizeValue("hello world")).toBe("hello world");
     });
   });
 

--- a/tests/unit/tools/changeRequests.test.ts
+++ b/tests/unit/tools/changeRequests.test.ts
@@ -121,6 +121,29 @@ describe("registerChangeRequestTools", () => {
     expect(query).toContain("assignment_groupLIKECAB");
   });
 
+  it("search_change_requests escapes encoded query injection characters", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.get.mockResolvedValue({
+      data: { result: [] },
+      headers: { "x-total-count": "0" },
+    });
+
+    await handlers.search_change_requests({
+      query: "test^NQassigned_to=admin",
+      state: "New^active=false",
+      type: "Normal,Emergency",
+      limit: 10,
+      offset: 0,
+    });
+
+    const call = snClient.get.mock.calls[0];
+    const query = call[1].params.sysparm_query;
+    expect(query).toContain("short_descriptionLIKEtest\\^NQassigned_to=admin");
+    expect(query).toContain("state=New\\^active=false");
+    expect(query).toContain("type=Normal\\,Emergency");
+  });
+
   // --- get_change_request ---
 
   it("get_change_request resolves by CHG number and returns self_link", async () => {

--- a/tests/unit/tools/incidents.test.ts
+++ b/tests/unit/tools/incidents.test.ts
@@ -242,6 +242,48 @@ describe("registerIncidentTools", () => {
     expect(query).toContain("assignment_groupLIKENetwork");
   });
 
+  it("search_incidents escapes encoded query injection characters in query", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.get.mockResolvedValue({
+      data: { result: [] },
+      headers: { "x-total-count": "0" },
+    });
+
+    await handlers.search_incidents({
+      query: "test^NQassigned_to=admin",
+      limit: 10,
+      offset: 0,
+    });
+
+    const call = snClient.get.mock.calls[0];
+    const query = call[1].params.sysparm_query;
+    expect(query).toContain("short_descriptionLIKEtest\\^NQassigned_to=admin");
+    // No unescaped ^NQ (which would start a new query)
+    expect(query).not.toMatch(/[^\\]\^NQ/);
+  });
+
+  it("search_incidents escapes injection characters in state and priority", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.get.mockResolvedValue({
+      data: { result: [] },
+      headers: { "x-total-count": "0" },
+    });
+
+    await handlers.search_incidents({
+      state: "New^NQpriority=1",
+      priority: "1,2",
+      limit: 10,
+      offset: 0,
+    });
+
+    const call = snClient.get.mock.calls[0];
+    const query = call[1].params.sysparm_query;
+    expect(query).toContain("state=New\\^NQpriority=1");
+    expect(query).toContain("priority=1\\,2");
+  });
+
   it("get_incident resolves by sys_id directly", async () => {
     const { handlers, snClient } = setup();
     const sysId = "0123456789abcdef0123456789abcdef";

--- a/tests/unit/tools/users.test.ts
+++ b/tests/unit/tools/users.test.ts
@@ -128,6 +128,45 @@ describe("registerUserTools", () => {
     });
   });
 
+  it("lookup_user escapes encoded query injection characters", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.get.mockResolvedValue({
+      data: { result: [] },
+      headers: { "x-total-count": "0" },
+    });
+
+    await handlers.lookup_user({
+      query: "test^NQassigned_to=admin",
+      limit: 10,
+    });
+
+    const call = snClient.get.mock.calls[0];
+    const query = call[1].params.sysparm_query;
+    // Caret must be escaped so it cannot break query logic
+    expect(query).toContain("nameLIKEtest\\^NQassigned_to=admin");
+    // No unescaped ^NQ (which would start a new query)
+    expect(query).not.toMatch(/[^\\]\^NQ/);
+  });
+
+  it("lookup_group escapes encoded query injection characters", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.get.mockResolvedValue({
+      data: { result: [] },
+      headers: { "x-total-count": "0" },
+    });
+
+    await handlers.lookup_group({
+      query: "IT^active=false",
+      limit: 10,
+    });
+
+    const call = snClient.get.mock.calls[0];
+    const query = call[1].params.sysparm_query;
+    expect(query).toBe("nameLIKEIT\\^active=false^active=true");
+  });
+
   it("get_my_profile returns authenticated user with sys_user self_link", async () => {
     const { handlers, snClient } = setup();
 


### PR DESCRIPTION
## Summary
- **Exports `sanitizeValue`** from `queryBuilder.ts` (previously private) so tool handlers can escape user input before interpolating into encoded queries
- **Sanitizes all user-supplied values** in `search_incidents`, `search_change_requests`, `lookup_user`, and `lookup_group` to prevent injection of ServiceNow encoded query operators (`^`, `^NQ`, `^OR`, `,`)
- **Adds 10 new tests** verifying injection characters are escaped across all affected tool handlers and the newly-exported `sanitizeValue` function

## Affected files
- `src/servicenow/queryBuilder.ts` — export `sanitizeValue`
- `src/tools/users.ts` — sanitize `lookup_user` and `lookup_group` queries
- `src/tools/incidents.ts` — sanitize `search_incidents` query, state, priority, assignment_group
- `src/tools/changeRequests.ts` — sanitize `search_change_requests` query, state, type, priority, assignment_group

## Test plan
- [x] All 327 tests pass (10 new, 317 existing unchanged)
- [x] Build succeeds with no errors
- [x] Existing test assertions unchanged — sanitization is transparent for inputs without special characters
- [x] New tests verify `^NQ` injection is escaped in user, incident, and change request search tools
- [x] New tests verify comma injection is escaped in state/priority fields

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)