### PR TITLE
security(deps): update hono to 4.12.8 to resolve prototype pollution vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2523,9 +2523,9 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.12.5",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
-      "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
+      "version": "4.12.8",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
+      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"


### PR DESCRIPTION
Fixes #30

## Summary
Updates hono dependency from 4.12.5 to 4.12.8 to resolve moderate severity Prototype Pollution vulnerability (GHSA-v8w9-8mx6-g223).

## Vulnerability Details
- **Package:** hono
- **Severity:** moderate
- **Affected versions:** <4.12.7
- **Advisory:** https://github.com/advisories/GHSA-v8w9-8mx6-g223
- **Issue:** Prototype Pollution possible through __proto__ key in parseBody({ dot: true })

## Verification

### Before Fix
```
$ npm audit
hono  <4.12.7
Severity: moderate
Hono vulnerable to Prototype Pollution - https://github.com/advisories/GHSA-v8w9-8mx6-g223
1 moderate severity vulnerability
```

### After Fix
```
$ npm audit
found 0 vulnerabilities

$ npm test
Test Files  31 passed (31)
Tests       331 passed (331)
```

## Changes
- Updated package-lock.json: hono 4.12.5 → 4.12.8

## AI Disclosure
This PR was generated by an autonomous agent (ClawOSS). All changes have been verified with automated tests.