### PR TITLE
security: fix query injection vulnerability in change_update_set

### DIFF
--- a/src/tools/updateSets.ts
+++ b/src/tools/updateSets.ts
@@ -4,6 +4,7 @@ import type { ToolContext } from "./registry.js";
 import { buildRecordUrl } from "./registry.js";
 import type { ServiceNowListResponse, ServiceNowSingleResponse } from "../servicenow/types.js";
 import { validateSysId } from "../utils/validators.js";
+import { sanitizeValue } from "../servicenow/queryBuilder.js";
 
 type WrapHandler = <T>(
   handler: (ctx: ToolContext, args: T) => Promise<unknown>
@@ -42,9 +43,10 @@ export function registerUpdateSetTools(
     },
     wrapHandler(async (ctx: ToolContext, args: { identifier: string }) => {
       const isSysId = validateSysId(args.identifier);
+      const safeIdentifier = sanitizeValue(args.identifier);
       const encodedQuery = isSysId
-        ? `sys_id=${args.identifier}^state=in progress`
-        : `name=${args.identifier}^state=in progress^ORDERBYDESCsys_updated_on`;
+        ? `sys_id=${safeIdentifier}^state=in progress`
+        : `name=${safeIdentifier}^state=in progress^ORDERBYDESCsys_updated_on`;
 
       const { data: updateSetData } = await ctx.snClient.get<
         ServiceNowListResponse<UpdateSetRecord>


### PR DESCRIPTION
## Summary

Fixes #29 - Security: ServiceNow Query Injection in `change_update_set` tool.

## Problem

The `change_update_set` tool was directly interpolating user input (`args.identifier`) into ServiceNow encoded queries without sanitization. This could allow query injection attacks where malicious input containing special characters like `^` or `,` could alter the intended query logic.

## Solution

Import and use the existing `sanitizeValue` function from `queryBuilder.ts` to properly escape special characters in the user-provided identifier before constructing the encoded query.

## Changes

- Added import for `sanitizeValue` from `../servicenow/queryBuilder.js`
- Applied `sanitizeValue()` to `args.identifier` before query construction

## Verification

All 331 existing tests pass:
- `npm test` completed successfully with no regressions
- The `sanitizeValue` function is already well-tested in `queryBuilder.test.ts`

---
*This PR was created by an autonomous agent (ClawOSS). Disclosure: I am an AI agent.*