### PR TITLE
fix(retry): clamp jittered delays to maxDelayMs

### DIFF
--- a/src/servicenow/retry.ts
+++ b/src/servicenow/retry.ts
@@ -34,13 +34,11 @@ function calculateDelay(
   options: Required<RetryOptions>,
   retryAfterMs?: number
 ): number {
-  const exponentialDelay = Math.min(
-    options.initialDelayMs * Math.pow(options.backoffMultiplier, attempt),
-    options.maxDelayMs
-  );
-  // Add 0-20% jitter
+  const exponentialDelay =
+    options.initialDelayMs * Math.pow(options.backoffMultiplier, attempt);
+  // Add 0-20% jitter, then clamp to the configured maximum delay.
   const jitter = exponentialDelay * (Math.random() * 0.2);
-  const calculatedDelay = exponentialDelay + jitter;
+  const calculatedDelay = Math.min(exponentialDelay + jitter, options.maxDelayMs);
   // Honor Retry-After if present and larger
   if (retryAfterMs !== undefined && retryAfterMs > calculatedDelay) {
     return retryAfterMs;

--- a/tests/unit/servicenow/retry.test.ts
+++ b/tests/unit/servicenow/retry.test.ts
@@ -352,15 +352,15 @@ describe("withRetry", () => {
       maxDelayMs: 5000,
     });
 
-    // initialDelayMs (50000) > maxDelayMs (5000), so capped at 5000 + 10% jitter = 5500
-    await vi.advanceTimersByTimeAsync(5500);
+    // Jitter should not push the retry delay beyond the configured max.
+    await vi.advanceTimersByTimeAsync(5000);
 
     const result = await promise;
 
     expect(result).toBe("ok");
     expect(loggerMocks.warn).toHaveBeenCalledWith(
       expect.objectContaining({
-        delayMs: 5500,
+        delayMs: 5000,
       }),
       "Retrying ServiceNow API call"
     );


### PR DESCRIPTION
## Why
The retry helper capped the exponential backoff before adding jitter, so once a delay hit `maxDelayMs` the subsequent jitter could still push the actual sleep time past the configured limit. That made retries wait longer than the caller explicitly allowed.

## What changed
- apply the `maxDelayMs` cap after adding jitter
- update the retry regression test to assert the delay never exceeds the configured maximum

## Reproduction
Before this change, the targeted retry test failed because the promise did not resolve within the configured cap:

```text
FAIL  tests/unit/servicenow/retry.test.ts > withRetry > caps delay at maxDelayMs
Error: Test timed out in 5000ms.
```

After this change:

```text
$ npm test -- --run tests/unit/servicenow/retry.test.ts
✓ tests/unit/servicenow/retry.test.ts (23 tests)

$ npm test
Test Files  31 passed (31)
Tests  331 passed (331)
```

Closes #36