### PR TITLE
fix(retry): cap delay after jitter

### DIFF
--- a/src/servicenow/retry.ts
+++ b/src/servicenow/retry.ts
@@ -34,14 +34,11 @@ function calculateDelay(
   options: Required<RetryOptions>,
   retryAfterMs?: number
 ): number {
-  const exponentialDelay = Math.min(
-    options.initialDelayMs * Math.pow(options.backoffMultiplier, attempt),
-    options.maxDelayMs
-  );
-  // Add 0-20% jitter
-  const jitter = exponentialDelay * (Math.random() * 0.2);
-  const calculatedDelay = exponentialDelay + jitter;
-  // Honor Retry-After if present and larger
+  const baseDelay = options.initialDelayMs * Math.pow(options.backoffMultiplier, attempt);
+  // Add 0-20% jitter before enforcing the final cap so the scheduled delay never exceeds maxDelayMs.
+  const jitter = baseDelay * (Math.random() * 0.2);
+  const calculatedDelay = Math.min(baseDelay + jitter, options.maxDelayMs);
+  // Honor Retry-After if present and larger.
   if (retryAfterMs !== undefined && retryAfterMs > calculatedDelay) {
     return retryAfterMs;
   }

--- a/tests/unit/servicenow/retry.test.ts
+++ b/tests/unit/servicenow/retry.test.ts
@@ -352,19 +352,19 @@ describe("withRetry", () => {
       maxDelayMs: 5000,
     });
 
-    // initialDelayMs (50000) > maxDelayMs (5000), so capped at 5000 + 10% jitter = 5500
-    await vi.advanceTimersByTimeAsync(5500);
+    await vi.advanceTimersByTimeAsync(5000);
 
     const result = await promise;
 
     expect(result).toBe("ok");
     expect(loggerMocks.warn).toHaveBeenCalledWith(
       expect.objectContaining({
-        delayMs: 5500,
+        delayMs: 5000,
       }),
       "Retrying ServiceNow API call"
     );
   });
+
 
   it("logs warning with correct metadata on each retry", async () => {
     const operation = vi


### PR DESCRIPTION
## Why
The retry helper capped the exponential backoff before adding jitter. That let the final scheduled delay exceed `maxDelayMs`, which contradicts the option contract and the issue report.

## What changed
- apply jitter to the uncapped base delay
- enforce `maxDelayMs` on the final delay value
- update the retry unit test to assert the capped final delay

## Verification
Failing expectation before fix:
```text
expected delayMs: 5500
actual configured maxDelayMs: 5000
```

Passing commands after fix:
```text
npm test -- --run tests/unit/servicenow/retry.test.ts
npm test
npm run build
```

Closes #36
