### PR TITLE
Add get_current_update_set tool, catalog variable improvements, and docker-compose fixes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,12 @@ services:
     build: .
     container_name: servicenow-mcp
     restart: unless-stopped
-    expose:
-      - "${MCP_PORT:-8080}"
+    ports:
+      - "${MCP_PORT:-8080}:${MCP_PORT:-8080}"
     env_file:
       - .env
+    environment:
+      REDIS_URL: "${DOCKER_REDIS_URL:-redis://:changeme@redis:6379}"
     depends_on:
       redis:
         condition: service_healthy

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -1,6 +1,6 @@
 [docs](../README.md) / tools
 
-# Tools (35)
+# Tools (36)
 
 All MCP tools provided by the server, grouped by domain.
 
@@ -41,8 +41,9 @@ All MCP tools provided by the server, grouped by domain.
 | 31 | `create_catalog_client_script` | [Catalog Admin](./catalog-admin.md) | Create a client-side script |
 | 32 | `create_catalog_ui_policy` | [Catalog Admin](./catalog-admin.md) | Create a UI policy |
 | 33 | `create_catalog_ui_policy_action` | [Catalog Admin](./catalog-admin.md) | Create a UI policy action |
-| 34 | `change_update_set` | [Update Sets](./update-sets.md) | Change the current update set |
-| 35 | `create_update_set` | [Update Sets](./update-sets.md) | Create a new update set |
+| 34 | `get_current_update_set` | [Update Sets](./update-sets.md) | Get the current update set |
+| 35 | `change_update_set` | [Update Sets](./update-sets.md) | Change the current update set |
+| 36 | `create_update_set` | [Update Sets](./update-sets.md) | Create a new update set |
 
 ## Common Patterns
 

--- a/docs/tools/catalog-admin.md
+++ b/docs/tools/catalog-admin.md
@@ -52,9 +52,10 @@ Create a form variable (field) on a catalog item.
 | `help_text` | string | No | Help text |
 | `hidden` | boolean | No | Hidden (default false) |
 | `read_only` | boolean | No | Read only (default false) |
-| `validate_regex` | string | No | Regex validation sys_id (`question_regex` record) for input format enforcement |
+| `attributes` | string | No | Widget attributes (e.g. `max_length=4`) |
+| `validate_regex` | string | No | Regex validation — sys_id or name of a `question_regex` record (e.g. `number`) |
 
-> **Tip**: Use `validate_regex` for simple format constraints (numeric, email, IP) instead of writing client scripts. It's declarative, works on all UI types, and requires no JavaScript.
+> **Tip**: Use `validate_regex` for simple format constraints (numeric, email, IP) instead of writing client scripts. It's declarative, works on all UI types, and requires no JavaScript. You can pass either the sys_id or the display name (e.g. `"number"`).
 
 ## `update_catalog_variable`
 

--- a/docs/tools/update-sets.md
+++ b/docs/tools/update-sets.md
@@ -1,8 +1,22 @@
 [docs](../README.md) / [tools](./README.md) / update-sets
 
-# Update Set Tools (2)
+# Update Set Tools (3)
 
 Tools for managing ServiceNow update sets. Update sets track configuration changes for deployment across instances.
+
+## `get_current_update_set`
+
+Get the authenticated user's current ServiceNow update set.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+
+_No parameters._
+
+**Behavior**:
+1. Reads the user's `sys_update_set` preference from `sys_user_preference`
+2. If no preference is set, returns `current_update_set: null` with a message indicating the Default update set is active
+3. If set, fetches and returns the full update set details
 
 ## `change_update_set`
 

--- a/src/tools/catalogAdmin.ts
+++ b/src/tools/catalogAdmin.ts
@@ -213,7 +213,8 @@ export function registerCatalogAdminTools(
       help_text: z.string().optional().describe("Help text"),
       hidden: z.boolean().optional().describe("Hidden (default false)"),
       read_only: z.boolean().optional().describe("Read only (default false)"),
-      validate_regex: z.string().optional().describe("Regex validation sys_id (question_regex record) for input format enforcement"),
+      attributes: z.string().optional().describe("Widget attributes (e.g. max_length=4)"),
+      validate_regex: z.string().optional().describe("Regex validation — sys_id or name of a question_regex record (e.g. 'number')"),
     },
     wrapHandler(
       async (
@@ -231,6 +232,7 @@ export function registerCatalogAdminTools(
           help_text?: string;
           hidden?: boolean;
           read_only?: boolean;
+          attributes?: string;
           validate_regex?: string;
         }
       ) => {
@@ -241,17 +243,6 @@ export function registerCatalogAdminTools(
               code: "VALIDATION_ERROR",
               message:
                 "Invalid cat_item sys_id format. Must be a 32-character hex string.",
-            },
-          };
-        }
-
-        if (args.validate_regex && !validateSysId(args.validate_regex)) {
-          return {
-            success: false,
-            error: {
-              code: "VALIDATION_ERROR",
-              message:
-                "Invalid validate_regex sys_id format. Must be a 32-character hex string (question_regex record).",
             },
           };
         }
@@ -273,6 +264,7 @@ export function registerCatalogAdminTools(
         if (args.help_text !== undefined) body.help_text = args.help_text;
         if (args.hidden !== undefined) body.hidden = args.hidden;
         if (args.read_only !== undefined) body.read_only = args.read_only;
+        if (args.attributes !== undefined) body.attributes = args.attributes;
         if (args.validate_regex !== undefined) body.validate_regex = args.validate_regex;
 
         const { data } = await ctx.snClient.post<

--- a/src/tools/updateSets.ts
+++ b/src/tools/updateSets.ts
@@ -32,6 +32,60 @@ export function registerUpdateSetTools(
   wrapHandler: WrapHandler
 ): void {
   server.tool(
+    "get_current_update_set",
+    "Get the authenticated user's current ServiceNow update set.",
+    {},
+    wrapHandler(async (ctx: ToolContext, _args: Record<string, never>) => {
+      const { data: preferenceData } = await ctx.snClient.get<
+        ServiceNowListResponse<UserPreferenceRecord>
+      >("/api/now/table/sys_user_preference", {
+        params: {
+          sysparm_query: `name=sys_update_set^user=${ctx.userSysId}`,
+          sysparm_limit: 1,
+          sysparm_fields: "sys_id,name,user,value",
+        },
+      });
+
+      if (!preferenceData.result.length || !preferenceData.result[0].value) {
+        return {
+          success: true,
+          data: {
+            current_update_set: null,
+            message:
+              "No update set preference found. The instance Default update set is active.",
+          },
+        };
+      }
+
+      const updateSetSysId = preferenceData.result[0].value;
+      const { data: updateSetData } = await ctx.snClient.get<
+        ServiceNowSingleResponse<UpdateSetRecord>
+      >(`/api/now/table/sys_update_set/${updateSetSysId}`, {
+        params: {
+          sysparm_fields: "sys_id,name,state,application,sys_updated_on",
+        },
+      });
+
+      return {
+        success: true,
+        data: {
+          current_update_set: {
+            sys_id: updateSetData.result.sys_id,
+            name: updateSetData.result.name,
+            state: updateSetData.result.state,
+            application: updateSetData.result.application,
+            self_link: buildRecordUrl(
+              ctx.instanceUrl,
+              "sys_update_set",
+              updateSetData.result.sys_id
+            ),
+          },
+        },
+      };
+    })
+  );
+
+  server.tool(
     "change_update_set",
     "Change the authenticated user's current ServiceNow update set by sys_id or name.",
     {

--- a/tests/unit/tools/catalogAdmin.test.ts
+++ b/tests/unit/tools/catalogAdmin.test.ts
@@ -263,24 +263,27 @@ describe("registerCatalogAdminTools", () => {
     expect(snClient.post).not.toHaveBeenCalled();
   });
 
-  it("create_catalog_variable returns VALIDATION_ERROR for invalid validate_regex", async () => {
+  it("create_catalog_variable accepts validate_regex by name", async () => {
     const { handlers, snClient } = setup();
+
+    snClient.post.mockResolvedValue({
+      data: { result: { sys_id: validSysId, name: "server_count" } },
+    });
 
     const result = (await handlers.create_catalog_variable({
       cat_item: validSysId,
       name: "server_count",
       question_text: "Number of Servers",
       type: "single_line_text",
-      validate_regex: "not-a-sys-id",
+      validate_regex: "number",
     })) as any;
 
-    expect(result.success).toBe(false);
-    expect(result.error.code).toBe("VALIDATION_ERROR");
-    expect(result.error.message).toContain("validate_regex");
-    expect(snClient.post).not.toHaveBeenCalled();
+    expect(result.success).toBe(true);
+    const body = snClient.post.mock.calls[0][1];
+    expect(body.validate_regex).toBe("number");
   });
 
-  it("create_catalog_variable includes validate_regex when provided", async () => {
+  it("create_catalog_variable accepts validate_regex by sys_id", async () => {
     const { handlers, snClient } = setup();
     const regexSysId = "aabbccddaabbccddaabbccddaabbccdd";
 
@@ -298,6 +301,25 @@ describe("registerCatalogAdminTools", () => {
 
     const body = snClient.post.mock.calls[0][1];
     expect(body.validate_regex).toBe(regexSysId);
+  });
+
+  it("create_catalog_variable includes attributes in POST body", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.post.mockResolvedValue({
+      data: { result: { sys_id: validSysId, name: "site_number" } },
+    });
+
+    await handlers.create_catalog_variable({
+      cat_item: validSysId,
+      name: "site_number",
+      question_text: "Site Number",
+      type: "single_line_text",
+      attributes: "max_length=4",
+    });
+
+    const body = snClient.post.mock.calls[0][1];
+    expect(body.attributes).toBe("max_length=4");
   });
 
   // --- update_catalog_variable ---

--- a/tests/unit/tools/updateSets.test.ts
+++ b/tests/unit/tools/updateSets.test.ts
@@ -52,6 +52,111 @@ describe("registerUpdateSetTools", () => {
     vi.clearAllMocks();
   });
 
+  describe("get_current_update_set", () => {
+    it("returns update set details when preference exists", async () => {
+      const { handlers, snClient } = setup();
+      const updateSetId = "0123456789abcdef0123456789abcdef";
+
+      snClient.get
+        .mockResolvedValueOnce({
+          data: {
+            result: [
+              {
+                sys_id: "pref-1",
+                name: "sys_update_set",
+                user: userSysId,
+                value: updateSetId,
+              },
+            ],
+          },
+          headers: {},
+        })
+        .mockResolvedValueOnce({
+          data: {
+            result: {
+              sys_id: updateSetId,
+              name: "My Update Set",
+              state: "in progress",
+              application: "Global",
+              sys_updated_on: "2026-03-17 12:00:00",
+            },
+          },
+          headers: {},
+        });
+
+      const result = (await handlers.get_current_update_set({})) as any;
+
+      expect(result.success).toBe(true);
+      expect(result.data.current_update_set).toEqual({
+        sys_id: updateSetId,
+        name: "My Update Set",
+        state: "in progress",
+        application: "Global",
+        self_link: `https://example.service-now.com/sys_update_set.do?sys_id=${updateSetId}`,
+      });
+      expect(snClient.get).toHaveBeenNthCalledWith(
+        1,
+        "/api/now/table/sys_user_preference",
+        {
+          params: {
+            sysparm_query: `name=sys_update_set^user=${userSysId}`,
+            sysparm_limit: 1,
+            sysparm_fields: "sys_id,name,user,value",
+          },
+        }
+      );
+      expect(snClient.get).toHaveBeenNthCalledWith(
+        2,
+        `/api/now/table/sys_update_set/${updateSetId}`,
+        {
+          params: {
+            sysparm_fields: "sys_id,name,state,application,sys_updated_on",
+          },
+        }
+      );
+    });
+
+    it("returns null when no preference exists", async () => {
+      const { handlers, snClient } = setup();
+
+      snClient.get.mockResolvedValueOnce({
+        data: { result: [] },
+        headers: {},
+      });
+
+      const result = (await handlers.get_current_update_set({})) as any;
+
+      expect(result.success).toBe(true);
+      expect(result.data.current_update_set).toBeNull();
+      expect(result.data.message).toContain("Default update set");
+      expect(snClient.get).toHaveBeenCalledTimes(1);
+    });
+
+    it("propagates error when update set lookup fails", async () => {
+      const { handlers, snClient } = setup();
+
+      snClient.get
+        .mockResolvedValueOnce({
+          data: {
+            result: [
+              {
+                sys_id: "pref-1",
+                name: "sys_update_set",
+                user: userSysId,
+                value: "missing12345678901234567890abcdef",
+              },
+            ],
+          },
+          headers: {},
+        })
+        .mockRejectedValueOnce(new Error("Not Found"));
+
+      await expect(
+        handlers.get_current_update_set({})
+      ).rejects.toThrow("Not Found");
+    });
+  });
+
   it("returns NOT_FOUND when no in-progress update set matches identifier", async () => {
     const { handlers, snClient } = setup();
 


### PR DESCRIPTION
## Summary
- Add `get_current_update_set` tool to read the user's active update set from `sys_user_preference`
- Allow `validate_regex` on catalog variables to accept a display name (e.g. `"number"`) in addition to sys_id
- Add `attributes` field to `create_catalog_variable` for widget attributes like `max_length`
- Fix `docker-compose.yml`: expose container port and set `REDIS_URL` for proper connectivity

## Test plan
- [x] 335 tests passing, including new tests for `get_current_update_set` (preference exists, no preference, error propagation)
- [x] Tests for `validate_regex` by name and `attributes` field on catalog variables
- [x] Build passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)