### PR TITLE
fix(paginator): avoid unnecessary API call when results align with page limit

### DIFF
--- a/src/servicenow/paginator.ts
+++ b/src/servicenow/paginator.ts
@@ -28,7 +28,7 @@ export async function paginateAll<T>(
     const response = await fetcher(limit, offset);
     totalCount = response.totalCount;
     allResults.push(...response.results);
-    if (response.results.length < limit) {
+    if (startOffset + allResults.length >= totalCount || response.results.length < limit) {
       return { results: allResults, totalCount, truncated: false };
     }
   }


### PR DESCRIPTION
## Problem
When the total number of records is an exact multiple of the limit, the paginator was making one extra API call that returned 0 results.

## Solution
Added a check using `totalCount` to break early when we've fetched all records:

```typescript
if (startOffset + allResults.length >= totalCount || response.results.length < limit) {
  return { results: allResults, totalCount, truncated: false };
}
```

## Changes
- Updated `src/servicenow/paginator.ts` to check against `totalCount` before continuing pagination

## Testing
- All existing tests pass (11/11)
- The fix addresses the exact scenario described in #66

Fixes #66