### PR TITLE
fix: prevent extra API call in Paginator

### DIFF
--- a/src/servicenow/paginator.ts
+++ b/src/servicenow/paginator.ts
@@ -31,6 +31,9 @@ export async function paginateAll<T>(
     if (response.results.length < limit) {
       return { results: allResults, totalCount, truncated: false };
     }
+    if (allResults.length >= totalCount) {
+      return { results: allResults, totalCount, truncated: false };
+    }
   }
 
   const truncated = startOffset + allResults.length < totalCount;


### PR DESCRIPTION
Fixes #66 — the Paginator was making one extra API call due to an off-by-one error.

## Bug

When `totalCount` equals `limit` (e.g., 100 == 100), the first page returns a full result set (100 results). The code then incorrectly continues to page 2, which returns 0 results, before finally stopping. This wastes an unnecessary API call.

## Fix

Added an early-exit check after accumulating results in each iteration: if `allResults.length >= totalCount`, return immediately. This prevents the extra call when a single full page exhausts the total count.