### PR TITLE
fix: set isError on tool handler logical failures

### DIFF
--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -96,7 +96,8 @@ export function registerAllTools(
           { userName: ctx.userName, duration },
           "Tool call completed"
         );
-        return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+        const isError = result != null && typeof result === "object" && "success" in result && result.success === false;
+        return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }], ...(isError ? { isError: true } : {}) };
       } catch (err: unknown) {
         const toolErr = (err as { toolError?: unknown })?.toolError;
         if (toolErr) {


### PR DESCRIPTION
Fixes #61

When a tool handler returns a result with `{ success: false }`, the MCP response now correctly sets `isError: true` so the client LLM interprets it as a failure.

**Change:** In `wrapHandler` in `src/tools/registry.ts`, check if the result is an object with `success: false` and include `isError: true` in the returned MCP payload.

All 335 existing tests pass.