### PR TITLE
fix: reduce default fetch limit in get_my_tasks and get_my_approvals

### DIFF
--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -27,9 +27,10 @@ export function registerTaskTools(
     "get_my_tasks",
     "Get all open tasks assigned to the authenticated user across all task types (incidents, requests, changes, etc.).",
     {
+      limit: z.number().int().min(1).max(100).default(20).describe("Maximum number of records to return"),
       offset: z.number().int().min(0).default(0).describe("Starting offset for continuation when previous response was truncated"),
     },
-    wrapHandler(async (ctx: ToolContext, args: { offset: number }) => {
+    wrapHandler(async (ctx: ToolContext, args: { limit: number; offset: number }) => {
       const { results, totalCount, truncated } = await paginateAll<Task>(
         async (limit, offset) => {
           const { data, headers } = await ctx.snClient.get<ServiceNowListResponse<Task>>(
@@ -49,7 +50,7 @@ export function registerTaskTools(
             totalCount: parseInt(headers["x-total-count"] || "0", 10),
           };
         },
-        { limit: 100, maxPages: 5, startOffset: args.offset }
+        { limit: args.limit, maxPages: 1, startOffset: args.offset }
       );
 
       return {
@@ -73,9 +74,10 @@ export function registerTaskTools(
     "get_my_approvals",
     "Get pending approvals for the authenticated user.",
     {
+      limit: z.number().int().min(1).max(100).default(20).describe("Maximum number of records to return"),
       offset: z.number().int().min(0).default(0).describe("Starting offset for continuation when previous response was truncated"),
     },
-    wrapHandler(async (ctx: ToolContext, args: { offset: number }) => {
+    wrapHandler(async (ctx: ToolContext, args: { limit: number; offset: number }) => {
       const { results, totalCount, truncated } = await paginateAll<Approval>(
         async (limit, offset) => {
           const { data, headers } = await ctx.snClient.get<ServiceNowListResponse<Approval>>(
@@ -95,7 +97,7 @@ export function registerTaskTools(
             totalCount: parseInt(headers["x-total-count"] || "0", 10),
           };
         },
-        { limit: 100, maxPages: 5, startOffset: args.offset }
+        { limit: args.limit, maxPages: 1, startOffset: args.offset }
       );
 
       return {


### PR DESCRIPTION
## Summary

Adds a configurable `limit` parameter (default 20, max 100) to both `get_my_tasks` and `get_my_approvals` tools instead of unconditionally fetching up to 500 records (limit=100 × maxPages=5).

## Changes

- Added `limit` parameter to Zod schemas for both tools (`z.number().int().min(1).max(100).default(20)`)
- Uses `args.limit` for `paginateAll` limit instead of hardcoded `100`
- Sets `maxPages: 1` to avoid unnecessary pagination when a limit is specified

## Testing

All 335 existing tests pass.

Fixes #58