### PR TITLE
fix: revoke old access token on refresh

### DIFF
--- a/src/auth/oauthProvider.ts
+++ b/src/auth/oauthProvider.ts
@@ -120,6 +120,7 @@ export class ServiceNowOAuthProvider implements OAuthServerProvider {
       userSysId,
       clientId,
       scopes,
+      currentAccessToken: accessToken,
     }, MCP_REFRESH_TOKEN_TTL);
 
     logger.info({ userSysId }, "MCP access token issued");
@@ -166,6 +167,11 @@ export class ServiceNowOAuthProvider implements OAuthServerProvider {
       }
     }
 
+    // Revoke the previous access token (if any) before issuing a new one
+    if (refreshData.currentAccessToken) {
+      await this.tokenStore.deleteMcpToken(refreshData.currentAccessToken);
+    }
+
     // Generate new access token
     const newAccessToken = crypto.randomBytes(32).toString("hex");
     const expiresAt = Math.floor(Date.now() / 1000) + MCP_ACCESS_TOKEN_TTL;
@@ -177,6 +183,12 @@ export class ServiceNowOAuthProvider implements OAuthServerProvider {
       scopes: effectiveScopes,
       expiresAt,
     }, MCP_ACCESS_TOKEN_TTL);
+
+    // Update the refresh grant to point to the new access token
+    await this.tokenStore.storeMcpRefreshToken(refreshToken, {
+      ...refreshData,
+      currentAccessToken: newAccessToken,
+    }, MCP_REFRESH_TOKEN_TTL);
 
     logger.info({ userSysId: refreshData.userSysId }, "MCP access token refreshed");
 

--- a/src/auth/tokenStore.ts
+++ b/src/auth/tokenStore.ts
@@ -42,6 +42,8 @@ export interface McpRefreshData {
   userSysId: string;
   clientId: string;
   scopes: string[];
+  /** The current access token tied to this refresh grant, so it can be revoked on rotation. */
+  currentAccessToken?: string;
 }
 
 export function createRedisClient(url: string): Redis {

--- a/tests/unit/auth/oauthProvider.test.ts
+++ b/tests/unit/auth/oauthProvider.test.ts
@@ -138,7 +138,7 @@ describe("ServiceNowOAuthProvider", () => {
       );
       expect(tokenStore.storeMcpRefreshToken).toHaveBeenCalledWith(
         tokens.refresh_token,
-        expect.objectContaining({ userSysId: "user-abc", clientId: "client-1" }),
+        expect.objectContaining({ userSysId: "user-abc", clientId: "client-1", currentAccessToken: tokens.access_token }),
         2592000
       );
     });
@@ -195,6 +195,7 @@ describe("ServiceNowOAuthProvider", () => {
         userSysId: "user-abc",
         clientId: "client-1",
         scopes: ["read"],
+        currentAccessToken: "old-access-token",
       });
       tokenStore.getToken.mockResolvedValue({ access_token: "sn-token" });
 
@@ -203,10 +204,16 @@ describe("ServiceNowOAuthProvider", () => {
       expect(tokens.access_token).toBeTruthy();
       expect(tokens.token_type).toBe("Bearer");
       expect(tokens.refresh_token).toBe("refresh-123");
+      expect(tokenStore.deleteMcpToken).toHaveBeenCalledWith("old-access-token");
       expect(tokenStore.storeMcpToken).toHaveBeenCalledWith(
         tokens.access_token,
         expect.objectContaining({ scopes: ["read"] }),
         3600
+      );
+      expect(tokenStore.storeMcpRefreshToken).toHaveBeenCalledWith(
+        "refresh-123",
+        expect.objectContaining({ currentAccessToken: tokens.access_token }),
+        2592000
       );
     });
 
@@ -215,6 +222,7 @@ describe("ServiceNowOAuthProvider", () => {
         userSysId: "user-abc",
         clientId: "client-1",
         scopes: ["read", "write"],
+        currentAccessToken: "old-access-token",
       });
       tokenStore.getToken.mockResolvedValue({ access_token: "sn-token" });
 
@@ -224,6 +232,7 @@ describe("ServiceNowOAuthProvider", () => {
         ["read"]
       );
 
+      expect(tokenStore.deleteMcpToken).toHaveBeenCalledWith("old-access-token");
       expect(tokenStore.storeMcpToken).toHaveBeenCalledWith(
         tokens.access_token,
         expect.objectContaining({ scopes: ["read"] }),


### PR DESCRIPTION
## Summary

When exchanging a refresh token for a new access token, the previous access token is now revoked from the token store before the new one is issued. This ensures only one active access token exists per refresh grant at any time, narrowing the window of vulnerability if a token is leaked.

## Changes

- Added optional `currentAccessToken` field to `McpRefreshData` to track the active access token per refresh grant
- `exchangeAuthorizationCode` now stores the initial access token reference in the refresh data
- `exchangeRefreshToken` now revokes the previous access token (if any) before issuing a new one, and updates the refresh data to point to the new token
- Updated tests to verify revocation behavior and refresh data updates

## Testing

All 22 existing tests pass.

Fixes #57