### PR TITLE
fix: add body parser middleware to MCP auth routes

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -66,6 +66,10 @@ export async function createApp(
     }
   });
 
+  // Body parsing middleware (required for OAuth token exchange and revocation)
+  app.use(express.json());
+  app.use(express.urlencoded({ extended: true }));
+
   // MCP SDK OAuth routes (/.well-known/*, /authorize, /token, /register, /revoke)
   app.use(
     mcpAuthRouter({


### PR DESCRIPTION
## Summary

Adds `express.json()` and `express.urlencoded()` middleware before the MCP Auth Router in `src/server.ts`.

Without body parsing middleware, `req.body` is `undefined` on POST requests to `/token` and `/revoke`, causing the OAuth token exchange flow to fail.

## Changes

- Added `express.json()` middleware
- Added `express.urlencoded({ extended: true })` middleware
- Both placed before `mcpAuthRouter()` mount

Fixes #45