### PR TITLE
fix: add error handling to prevent process crash on /mcp route

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,4 @@
-import express, { type Request, type Response } from "express";
+import express, { type NextFunction, type Request, type Response } from "express";
 import cors from "cors";
 import helmet from "helmet";
 import { randomUUID } from "node:crypto";
@@ -121,27 +121,31 @@ export async function createApp(
   }
 
   // POST /mcp — handles initialize + tool calls (bearer auth required)
-  app.post("/mcp", bearerAuth, async (req: Request, res: Response) => {
+  app.post("/mcp", bearerAuth, async (req: Request, res: Response, next: NextFunction) => {
     const sessionId = req.headers["mcp-session-id"] as string | undefined;
 
-    if (sessionId && sessions.has(sessionId)) {
-      // Existing session — route to its transport
-      const entry = sessions.get(sessionId)!;
+    try {
+      if (sessionId && sessions.has(sessionId)) {
+        // Existing session — route to its transport
+        const entry = sessions.get(sessionId)!;
+        await entry.transport.handleRequest(req, res);
+        return;
+      }
+
+      // No session or unknown session — create new session
+      const entry = createMcpSession();
+
+      // Connect server to transport
+      await entry.server.connect(entry.transport);
+
       await entry.transport.handleRequest(req, res);
-      return;
+    } catch (err) {
+      next(err);
     }
-
-    // No session or unknown session — create new session
-    const entry = createMcpSession();
-
-    // Connect server to transport
-    await entry.server.connect(entry.transport);
-
-    await entry.transport.handleRequest(req, res);
   });
 
   // GET /mcp — SSE stream for notifications (Streamable HTTP spec)
-  app.get("/mcp", bearerAuth, async (req: Request, res: Response) => {
+  app.get("/mcp", bearerAuth, async (req: Request, res: Response, next: NextFunction) => {
     const sessionId = req.headers["mcp-session-id"] as string | undefined;
 
     if (!sessionId || !sessions.has(sessionId)) {
@@ -149,12 +153,16 @@ export async function createApp(
       return;
     }
 
-    const entry = sessions.get(sessionId)!;
-    await entry.transport.handleRequest(req, res);
+    try {
+      const entry = sessions.get(sessionId)!;
+      await entry.transport.handleRequest(req, res);
+    } catch (err) {
+      next(err);
+    }
   });
 
   // DELETE /mcp — close session
-  app.delete("/mcp", bearerAuth, async (req: Request, res: Response) => {
+  app.delete("/mcp", bearerAuth, async (req: Request, res: Response, next: NextFunction) => {
     const sessionId = req.headers["mcp-session-id"] as string | undefined;
 
     if (!sessionId || !sessions.has(sessionId)) {
@@ -162,11 +170,15 @@ export async function createApp(
       return;
     }
 
-    const entry = sessions.get(sessionId)!;
-    await entry.transport.close();
-    sessions.delete(sessionId);
-    logger.info({ sessionId }, "MCP session terminated by client");
-    res.status(200).json({ message: "Session closed" });
+    try {
+      const entry = sessions.get(sessionId)!;
+      await entry.transport.close();
+      sessions.delete(sessionId);
+      logger.info({ sessionId }, "MCP session terminated by client");
+      res.status(200).json({ message: "Session closed" });
+    } catch (err) {
+      next(err);
+    }
   });
 
   return app;


### PR DESCRIPTION
## Summary

Wrap async handlers for POST, GET, and DELETE `/mcp` routes in `try/catch` blocks that forward errors via `next(err)`, preventing unhandled promise rejections from crashing the process.

## Changes

- Added `NextFunction` import from express
- Wrapped `handleRequest()` and `transport.close()` calls in try/catch in all three `/mcp` route handlers
- Errors are forwarded to Express error middleware via `next(err)` instead of being silently dropped

## Testing

TypeScript compilation passes (no new errors). Existing test suite has pre-existing dependency resolution issues unrelated to this change.

Fixes #41