### PR TITLE
fix: sanitize raw API response body in mapServiceNowError

### DIFF
--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -64,8 +64,7 @@ export function mapServiceNowError(
       }
       return createToolError(
         "UNEXPECTED_ERROR",
-        "An unexpected error occurred.",
-        responseBody
+        "An unexpected error occurred."
       );
   }
 }


### PR DESCRIPTION
## Summary

Removes raw `responseBody` from the client-facing `UNEXPECTED_ERROR` in `mapServiceNowError`.

ServiceNow error responses often contain stack traces, internal table names, or SQL fragments. Passing this directly to the MCP client exposes sensitive internal details.

The errors are already tracked by `reference_id` in server logs, so admins can still look up the full details.

Fixes #37

## Test

All 179 tests pass.