### PR TITLE
fix: add global Express error handler to prevent stack trace leaks

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,4 @@
-import express, { type Request, type Response } from "express";
+import express, { type Request, type Response, type NextFunction } from "express";
 import cors from "cors";
 import helmet from "helmet";
 import { randomUUID } from "node:crypto";
@@ -168,6 +168,19 @@ export async function createApp(
     logger.info({ sessionId }, "MCP session terminated by client");
     res.status(200).json({ message: "Session closed" });
   });
+
+  // Global error handler — returns JSON, hides stack traces in production
+  app.use(
+    (err: Error, _req: Request, res: Response, _next: NextFunction) => {
+      const isDev = process.env.NODE_ENV !== "production";
+      logger.error({ err }, "Unhandled error");
+
+      res.status(500).json({
+        error: "Internal Server Error",
+        ...(isDev && { message: err.message, stack: err.stack }),
+      });
+    }
+  );
 
   return app;
 }


### PR DESCRIPTION
## Summary

Fixes #63

Adds a global Express error handler at the end of the middleware stack in `src/server.ts` to catch any unhandled errors and return a clean JSON 500 response.

### What changed
- Added a four-argument Express error handler after all routes
- **Production**: Returns `{"error": "Internal Server Error"}` with no stack trace
- **Development** (`NODE_ENV !== production`): Includes `message` and `stack` for debugging
- Errors are logged via the existing `logger"

### Security impact
Prevents information exposure (stack traces, internal file paths) to API clients in production.