### PR TITLE
fix: resolve SSE stream Catch-22 - allow clients to connect

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -141,15 +141,20 @@ export async function createApp(
   });
 
   // GET /mcp — SSE stream for notifications (Streamable HTTP spec)
+  // Creates a new session if no valid session ID is provided
   app.get("/mcp", bearerAuth, async (req: Request, res: Response) => {
     const sessionId = req.headers["mcp-session-id"] as string | undefined;
 
-    if (!sessionId || !sessions.has(sessionId)) {
-      res.status(400).json({ error: "Invalid or missing session ID" });
+    if (sessionId && sessions.has(sessionId)) {
+      // Existing session — open SSE stream
+      const entry = sessions.get(sessionId)!;
+      await entry.transport.handleRequest(req, res);
       return;
     }
 
-    const entry = sessions.get(sessionId)!;
+    // No session or unknown session — create new session and return SSE stream
+    const entry = createMcpSession();
+    await entry.server.connect(entry.transport);
     await entry.transport.handleRequest(req, res);
   });
 

--- a/tests/unit/server.test.ts
+++ b/tests/unit/server.test.ts
@@ -164,12 +164,22 @@ describe("createApp", () => {
     expect(response.headers["access-control-allow-origin"]).toBeUndefined();
   });
 
-  it("rejects GET /mcp with missing or unknown session", async () => {
+  it("creates session on GET /mcp when no session ID provided", async () => {
     const redis = { ping: vi.fn().mockResolvedValue("PONG") };
     const app = await createApp(baseConfig as any, redis as any);
 
-    await request(app).get("/mcp").expect(400);
-    await request(app).get("/mcp").set("mcp-session-id", "missing").expect(400);
+    // GET /mcp without session should create a new session and return SSE stream
+    await request(app).get("/mcp").expect(200);
+    expect(mocks.transportInstances.length).toBe(1);
+  });
+
+  it("creates session on GET /mcp with unknown session ID", async () => {
+    const redis = { ping: vi.fn().mockResolvedValue("PONG") };
+    const app = await createApp(baseConfig as any, redis as any);
+
+    // GET /mcp with unknown session ID should create a new session
+    await request(app).get("/mcp").set("mcp-session-id", "missing").expect(200);
+    expect(mocks.transportInstances.length).toBe(1);
   });
 
   it("rejects DELETE /mcp for missing session", async () => {
@@ -227,6 +237,7 @@ describe("createApp", () => {
       .expect(200);
 
     expect(transport.close).toHaveBeenCalledTimes(1);
-    await request(app).get("/mcp").set("mcp-session-id", sessionId).expect(400);
+    // After session deletion, GET /mcp with old session ID creates a new session
+    await request(app).get("/mcp").set("mcp-session-id", sessionId).expect(200);
   });
 });


### PR DESCRIPTION
## Summary

Fixes the SSE stream Catch-22 described in #49 where clients cannot connect to the MCP server.

## Problem

- `GET /mcp` required an `mcp-session-id` header, returning 400 if missing
- `POST /mcp` created sessions but the server-generated session ID was never returned to the client
- Result: clients could never obtain a session ID to establish SSE streams

## Fix

- `GET /mcp` now creates a new session when no valid `mcp-session-id` is provided, instead of returning 400
- This follows the MCP Streamable HTTP Transport pattern where GET establishes the SSE stream and the transport sends the session ID via SSE event
- Updated tests to reflect the new behavior

Fixes #49