### PR TITLE
fix(security): remove insecure default Redis password fallback

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     env_file:
       - .env
     environment:
-      REDIS_URL: "${DOCKER_REDIS_URL:-redis://:changeme@redis:6379}"
+      REDIS_URL: "${DOCKER_REDIS_URL:-redis://:${REDIS_PASSWORD}@redis:6379}"
     depends_on:
       redis:
         condition: service_healthy
@@ -25,14 +25,14 @@ services:
     restart: unless-stopped
     command: >
       redis-server
-      --requirepass ${REDIS_PASSWORD:-changeme}
+      --requirepass ${REDIS_PASSWORD}
       --maxmemory 128mb
       --maxmemory-policy allkeys-lru
       --appendonly yes
     volumes:
       - redis-data:/data
     healthcheck:
-      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD:-changeme}", "ping"]
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
       interval: 10s
       timeout: 3s
       retries: 5


### PR DESCRIPTION
## Summary
Replace hardcoded `changeme` password defaults in `docker-compose.yml` with the required `REDIS_PASSWORD` environment variable.

## Changes
- Removed `:-
changeme` fallback from `REDIS_PASSWORD` in redis command and healthcheck
- Removed `:-
redis://:changeme@redis:6379` fallback from `DOCKER_REDIS_URL` 
- `REDIS_PASSWORD` is already documented in `.env.example` (auto-generated by setup.sh)

## Security Impact
Prevents accidental deployment with a weak, guessable default password that would expose encrypted tokens, rate-limit data, and OAuth state.

Closes #60