### PR TITLE
fix: handleToolError recognizes already-formatted ToolError objects

### DIFF
--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -70,7 +70,20 @@ export function mapServiceNowError(
   }
 }
 
+function isToolError(err: unknown): err is ToolError {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (err as ToolError).success === false &&
+    typeof (err as ToolError).error?.code === "string"
+  );
+}
+
 export function handleToolError(err: unknown): ToolError {
+  if (isToolError(err)) {
+    return err;
+  }
+
   if (isServiceNowApiError(err)) {
     return mapServiceNowError(err.statusCode, err.responseBody);
   }


### PR DESCRIPTION
When `getContext` throws a `createToolError` (e.g. `RATE_LIMITED`), `wrapHandler`'s catch block passed the plain object to `handleToolError` which didn't recognize it, treating it as an unexpected error and returning an opaque `UNEXPECTED_ERROR` to the client.

Adds an `isToolError` type guard at the top of `handleToolError` to detect already-formatted `ToolError` objects (checking `success === false` and `error.code` is a string) and return them directly.

Fixes #46