### PR TITLE
fix: Prevent unnecessary API call when results align with page limit

### DIFF
--- a/src/servicenow/paginator.ts
+++ b/src/servicenow/paginator.ts
@@ -28,7 +28,7 @@ export async function paginateAll<T>(
     const response = await fetcher(limit, offset);
     totalCount = response.totalCount;
     allResults.push(...response.results);
-    if (response.results.length < limit) {
+    if (response.results.length < limit || offset + response.results.length >= totalCount) {
       return { results: allResults, totalCount, truncated: false };
     }
   }


### PR DESCRIPTION
## Description
Fixes issue #66 where the Paginator makes an unnecessary extra API call when the total number of records is an exact multiple of the limit.

## Problem
The old condition `response.results.length < limit` only checks if the current page has fewer results than the limit. When total records equals the limit (e.g., exactly 100 records with limit=100), the loop continues and makes another API call that returns 0 results.

## Solution
Changed the condition to also check if we have fetched all available results using `offset + response.results.length >= totalCount`.

```typescript
// Before
if (response.results.length < limit) {

// After  
if (response.results.length < limit || offset + response.results.length >= totalCount) {
```

## Testing
- When totalCount is exactly 100 with limit=100: stops after 1 call (previously made 2)
- When totalCount is 150 with limit=100: stops after 2 calls (correct behavior)
- When totalCount is 250 with limit=100: stops after 3 calls (at maxPages or all fetched)

Closes #66