### PR TITLE
Add search_scheduled_jobs and get_scheduled_job tools

### DIFF
--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -1,6 +1,6 @@
 [docs](../README.md) / tools
 
-# Tools (36)
+# Tools (38)
 
 All MCP tools provided by the server, grouped by domain.
 
@@ -44,6 +44,8 @@ All MCP tools provided by the server, grouped by domain.
 | 34 | `get_current_update_set` | [Update Sets](./update-sets.md) | Get the current update set |
 | 35 | `change_update_set` | [Update Sets](./update-sets.md) | Change the current update set |
 | 36 | `create_update_set` | [Update Sets](./update-sets.md) | Create a new update set |
+| 37 | `search_scheduled_jobs` | [Scheduled Jobs](./scheduled-jobs.md) | Search Scheduled Script Executions |
+| 38 | `get_scheduled_job` | [Scheduled Jobs](./scheduled-jobs.md) | Get a Scheduled Script Execution by sys_id |
 
 ## Common Patterns
 

--- a/docs/tools/scheduled-jobs.md
+++ b/docs/tools/scheduled-jobs.md
@@ -1,0 +1,35 @@
+[docs](../README.md) / [tools](./README.md) / scheduled-jobs
+
+# Scheduled Jobs Tools (2)
+
+Read-only tools for inspecting Scheduled Script Executions (`sysauto_script`) — useful for tracing background automations such as monthly incident generators.
+
+## `search_scheduled_jobs`
+
+Search Scheduled Script Executions with filters. Returns a paginated summary list (script body excluded).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | No | Job name LIKE filter |
+| `script_contains` | string | No | Match jobs whose script body CONTAINS this substring |
+| `run_as` | string | No | Run-as user `sys_id` (32 hex chars) |
+| `active` | boolean | No | Filter by active flag |
+| `run_type` | string | No | e.g. `periodically`, `monthly`, `weekly`, `daily`, `on_demand` |
+| `limit` | number | No | 1-100, default 20 |
+| `offset` | number | No | Pagination offset, default 0 |
+
+**Returns**: Job summaries with `sys_id`, `name`, `active`, `run_type`, `run_period`, `run_dayofmonth`, `run_dayofweek`, `run_time`, `run_start`, `run_as`, `conditional`, `sys_class_name`, `sys_updated_on`, and `self_link`.
+
+## `get_scheduled_job`
+
+Get full details of a Scheduled Script Execution by `sys_id`, including the `script` body and `condition`.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `sys_id` | string | Yes | Scheduled job `sys_id` (32 hex chars) |
+
+**Returns**: The full job record plus `self_link`.
+
+---
+
+**See also**: [Update Sets](./update-sets.md) · [Input Validation](../security/input-validation.md)

--- a/docs/tools/scheduled-jobs.md
+++ b/docs/tools/scheduled-jobs.md
@@ -11,7 +11,7 @@ Search Scheduled Script Executions with filters. Returns a paginated summary lis
 | Parameter | Type | Required | Description |
 |---|---|---|---|
 | `name` | string | No | Job name LIKE filter |
-| `script_contains` | string | No | Match jobs whose script body CONTAINS this substring |
+| `script_contains` | string | No | Match jobs whose script body contains this substring (LIKE) |
 | `run_as` | string | No | Run-as user `sys_id` (32 hex chars) |
 | `active` | boolean | No | Filter by active flag |
 | `run_type` | string | No | e.g. `periodically`, `monthly`, `weekly`, `daily`, `on_demand` |

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -16,6 +16,7 @@ import { registerCatalogTools } from "./catalog.js";
 import { registerUpdateSetTools } from "./updateSets.js";
 import { registerChangeRequestTools } from "./changeRequests.js";
 import { registerCatalogAdminTools } from "./catalogAdmin.js";
+import { registerScheduledJobTools } from "./scheduledJobs.js";
 import { registerCatalogPrompts } from "../prompts/catalog.js";
 import { registerIncidentPrompts } from "../prompts/incidents.js";
 import { registerChangeRequestPrompts } from "../prompts/changeRequests.js";
@@ -116,6 +117,7 @@ export function registerAllTools(
   registerUpdateSetTools(server, wrapHandler);
   registerChangeRequestTools(server, wrapHandler);
   registerCatalogAdminTools(server, wrapHandler);
+  registerScheduledJobTools(server, wrapHandler);
 
   registerCatalogPrompts(server);
   registerResources(server, getContext);

--- a/src/tools/scheduledJobs.ts
+++ b/src/tools/scheduledJobs.ts
@@ -115,7 +115,7 @@ export function registerScheduledJobTools(
         }
         if (args.script_contains) {
           queryParts.push(
-            `scriptCONTAINS${sanitizeValue(args.script_contains)}`
+            `scriptLIKE${sanitizeValue(args.script_contains)}`
           );
         }
         if (args.run_as) {

--- a/src/tools/scheduledJobs.ts
+++ b/src/tools/scheduledJobs.ts
@@ -1,0 +1,216 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { ToolContext } from "./registry.js";
+import { buildRecordUrl } from "./registry.js";
+import type {
+  ServiceNowListResponse,
+  ServiceNowSingleResponse,
+} from "../servicenow/types.js";
+import { sanitizeValue } from "../servicenow/queryBuilder.js";
+import { validateSysId } from "../utils/validators.js";
+
+type WrapHandler = <T>(
+  handler: (ctx: ToolContext, args: T) => Promise<unknown>
+) => (args: T) => Promise<{
+  content: { type: "text"; text: string }[];
+  isError?: boolean;
+}>;
+
+const SUMMARY_FIELDS = [
+  "sys_id",
+  "name",
+  "active",
+  "run_type",
+  "run_period",
+  "run_dayofmonth",
+  "run_dayofweek",
+  "run_time",
+  "run_start",
+  "run_as",
+  "conditional",
+  "sys_class_name",
+  "sys_updated_on",
+].join(",");
+
+const DETAIL_FIELDS = [
+  SUMMARY_FIELDS,
+  "script",
+  "condition",
+  "description",
+  "sys_created_on",
+  "sys_created_by",
+  "sys_updated_by",
+].join(",");
+
+interface ScheduledJobRecord {
+  sys_id: string;
+  name?: string;
+  [key: string]: unknown;
+}
+
+export function registerScheduledJobTools(
+  server: McpServer,
+  wrapHandler: WrapHandler
+): void {
+  // search_scheduled_jobs
+  server.tool(
+    "search_scheduled_jobs",
+    "Search Scheduled Script Executions (sysauto_script). Useful for finding background jobs that create or update records on a schedule (e.g. monthly incident generators). Returns a paginated summary list.",
+    {
+      name: z
+        .string()
+        .optional()
+        .describe("Filter by job name (LIKE match)"),
+      script_contains: z
+        .string()
+        .optional()
+        .describe(
+          "Filter to jobs whose script body CONTAINS this substring (e.g. a table name, group name, or short description)"
+        ),
+      run_as: z
+        .string()
+        .optional()
+        .describe("Filter by run-as user sys_id (32 hex chars)"),
+      active: z
+        .boolean()
+        .optional()
+        .describe("Filter by active flag"),
+      run_type: z
+        .string()
+        .optional()
+        .describe(
+          "Filter by run_type (e.g. 'periodically', 'monthly', 'weekly', 'daily', 'on_demand')"
+        ),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .default(20)
+        .describe("Maximum results"),
+      offset: z
+        .number()
+        .int()
+        .min(0)
+        .default(0)
+        .describe("Result offset for pagination"),
+    },
+    wrapHandler(
+      async (
+        ctx: ToolContext,
+        args: {
+          name?: string;
+          script_contains?: string;
+          run_as?: string;
+          active?: boolean;
+          run_type?: string;
+          limit: number;
+          offset: number;
+        }
+      ) => {
+        const queryParts: string[] = [];
+
+        if (args.name) {
+          queryParts.push(`nameLIKE${sanitizeValue(args.name)}`);
+        }
+        if (args.script_contains) {
+          queryParts.push(
+            `scriptCONTAINS${sanitizeValue(args.script_contains)}`
+          );
+        }
+        if (args.run_as) {
+          if (!validateSysId(args.run_as)) {
+            return {
+              success: false,
+              error: {
+                code: "VALIDATION_ERROR",
+                message: "run_as must be a 32-character sys_id",
+              },
+            };
+          }
+          queryParts.push(`run_as=${args.run_as}`);
+        }
+        if (typeof args.active === "boolean") {
+          queryParts.push(`active=${args.active ? "true" : "false"}`);
+        }
+        if (args.run_type) {
+          queryParts.push(`run_type=${sanitizeValue(args.run_type)}`);
+        }
+
+        queryParts.push("ORDERBYDESCsys_updated_on");
+
+        const { data, headers } = await ctx.snClient.get<
+          ServiceNowListResponse<ScheduledJobRecord>
+        >("/api/now/table/sysauto_script", {
+          params: {
+            sysparm_query: queryParts.join("^"),
+            sysparm_limit: args.limit,
+            sysparm_offset: args.offset,
+            sysparm_fields: SUMMARY_FIELDS,
+          },
+        });
+
+        return {
+          success: true,
+          data: data.result.map((r) => ({
+            ...r,
+            self_link: buildRecordUrl(
+              ctx.instanceUrl,
+              "sysauto_script",
+              r.sys_id
+            ),
+          })),
+          metadata: {
+            total_count: parseInt(headers["x-total-count"] || "0", 10),
+            returned_count: data.result.length,
+            offset: args.offset,
+          },
+        };
+      }
+    )
+  );
+
+  // get_scheduled_job
+  server.tool(
+    "get_scheduled_job",
+    "Get full details of a Scheduled Script Execution (sysauto_script) by sys_id, including the script body and condition.",
+    {
+      sys_id: z
+        .string()
+        .describe("Scheduled job sys_id (32 hex chars)"),
+    },
+    wrapHandler(
+      async (ctx: ToolContext, args: { sys_id: string }) => {
+        if (!validateSysId(args.sys_id)) {
+          return {
+            success: false,
+            error: {
+              code: "VALIDATION_ERROR",
+              message: "sys_id must be a 32-character sys_id",
+            },
+          };
+        }
+
+        const { data } = await ctx.snClient.get<
+          ServiceNowSingleResponse<ScheduledJobRecord>
+        >(`/api/now/table/sysauto_script/${args.sys_id}`, {
+          params: {
+            sysparm_fields: DETAIL_FIELDS,
+          },
+        });
+
+        return {
+          success: true,
+          data: {
+            ...data.result,
+            self_link: buildRecordUrl(
+              ctx.instanceUrl,
+              "sysauto_script",
+              data.result.sys_id
+            ),
+          },
+        };
+      }
+    )
+  );
+}

--- a/tests/unit/tools/registry.test.ts
+++ b/tests/unit/tools/registry.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   registerUpdateSetTools: vi.fn(),
   registerChangeRequestTools: vi.fn(),
   registerCatalogAdminTools: vi.fn(),
+  registerScheduledJobTools: vi.fn(),
   registerCatalogPrompts: vi.fn(),
   registerIncidentPrompts: vi.fn(),
   registerChangeRequestPrompts: vi.fn(),
@@ -53,6 +54,10 @@ vi.mock("../../../src/tools/changeRequests.js", () => ({
 
 vi.mock("../../../src/tools/catalogAdmin.js", () => ({
   registerCatalogAdminTools: mocks.registerCatalogAdminTools,
+}));
+
+vi.mock("../../../src/tools/scheduledJobs.js", () => ({
+  registerScheduledJobTools: mocks.registerScheduledJobTools,
 }));
 
 vi.mock("../../../src/prompts/catalog.js", () => ({
@@ -160,6 +165,7 @@ describe("registerAllTools", () => {
     mocks.registerUpdateSetTools.mockImplementation(() => {});
     mocks.registerChangeRequestTools.mockImplementation(() => {});
     mocks.registerCatalogAdminTools.mockImplementation(() => {});
+    mocks.registerScheduledJobTools.mockImplementation(() => {});
     mocks.registerCatalogPrompts.mockImplementation(() => {});
     mocks.registerIncidentPrompts.mockImplementation(() => {});
     mocks.registerChangeRequestPrompts.mockImplementation(() => {});

--- a/tests/unit/tools/scheduledJobs.test.ts
+++ b/tests/unit/tools/scheduledJobs.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerScheduledJobTools } from "../../../src/tools/scheduledJobs.js";
+import type { ToolContext } from "../../../src/tools/registry.js";
+
+type WrappedHandler<T = unknown> = (args: T) => Promise<unknown>;
+
+describe("registerScheduledJobTools", () => {
+  const userSysId = "abc123def456abc123def456abc12345";
+
+  function setup() {
+    const handlers: Record<string, WrappedHandler> = {};
+
+    const server = {
+      tool: vi.fn(
+        (
+          name: string,
+          _description: string,
+          _schema: unknown,
+          handler: WrappedHandler
+        ) => {
+          handlers[name] = handler;
+        }
+      ),
+    };
+
+    const snClient = {
+      get: vi.fn(),
+      patch: vi.fn(),
+      post: vi.fn(),
+    };
+
+    const ctx: ToolContext = {
+      snClient: snClient as unknown as ToolContext["snClient"],
+      instanceUrl: "https://example.service-now.com",
+      userSysId,
+      userName: "john.doe",
+      displayName: "John Doe",
+    };
+
+    const wrapHandler = <T>(
+      handler: (context: ToolContext, args: T) => Promise<unknown>
+    ) => {
+      return async (args: T) => handler(ctx, args);
+    };
+
+    registerScheduledJobTools(server as never, wrapHandler);
+
+    return { handlers, snClient, server };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("search_scheduled_jobs builds query with name and script_contains and returns self_link", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.get.mockResolvedValue({
+      data: {
+        result: [
+          {
+            sys_id: "job-sys-id-001",
+            name: "Monthly Site Openings",
+            active: "true",
+            run_type: "monthly",
+          },
+        ],
+      },
+      headers: { "x-total-count": "1" },
+    });
+
+    const result = (await handlers.search_scheduled_jobs({
+      name: "Monthly",
+      script_contains: "Open Site Openings",
+      active: true,
+      limit: 20,
+      offset: 0,
+    })) as {
+      success: boolean;
+      data: { sys_id: string; self_link: string }[];
+      metadata: { total_count: number; returned_count: number; offset: number };
+    };
+
+    expect(snClient.get).toHaveBeenCalledWith(
+      "/api/now/table/sysauto_script",
+      expect.objectContaining({
+        params: expect.objectContaining({
+          sysparm_query:
+            "nameLIKEMonthly^scriptCONTAINSOpen Site Openings^active=true^ORDERBYDESCsys_updated_on",
+          sysparm_limit: 20,
+          sysparm_offset: 0,
+        }),
+      })
+    );
+    expect(result.success).toBe(true);
+    expect(result.data[0].self_link).toBe(
+      "https://example.service-now.com/sysauto_script.do?sys_id=job-sys-id-001"
+    );
+    expect(result.metadata).toEqual({
+      total_count: 1,
+      returned_count: 1,
+      offset: 0,
+    });
+  });
+
+  it("search_scheduled_jobs accepts run_as as a valid sys_id", async () => {
+    const { handlers, snClient } = setup();
+    const runAs = "ed72db164738b6d4718d8a12736d4339";
+
+    snClient.get.mockResolvedValue({
+      data: { result: [] },
+      headers: { "x-total-count": "0" },
+    });
+
+    await handlers.search_scheduled_jobs({
+      run_as: runAs,
+      limit: 20,
+      offset: 0,
+    });
+
+    expect(snClient.get).toHaveBeenCalledWith(
+      "/api/now/table/sysauto_script",
+      expect.objectContaining({
+        params: expect.objectContaining({
+          sysparm_query: `run_as=${runAs}^ORDERBYDESCsys_updated_on`,
+        }),
+      })
+    );
+  });
+
+  it("search_scheduled_jobs rejects invalid run_as", async () => {
+    const { handlers } = setup();
+
+    const result = (await handlers.search_scheduled_jobs({
+      run_as: "not-a-sys-id",
+      limit: 20,
+      offset: 0,
+    })) as { success: boolean; error: { code: string } };
+
+    expect(result.success).toBe(false);
+    expect(result.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("get_scheduled_job fetches by sys_id and returns self_link", async () => {
+    const { handlers, snClient } = setup();
+    const jobSysId = "0123456789abcdef0123456789abcdef";
+
+    snClient.get.mockResolvedValue({
+      data: {
+        result: {
+          sys_id: jobSysId,
+          name: "PDI Monthly Reminder",
+          script: "// create incident",
+        },
+      },
+      headers: {},
+    });
+
+    const result = (await handlers.get_scheduled_job({
+      sys_id: jobSysId,
+    })) as { success: boolean; data: { self_link: string } };
+
+    expect(snClient.get).toHaveBeenCalledWith(
+      `/api/now/table/sysauto_script/${jobSysId}`,
+      expect.objectContaining({
+        params: expect.objectContaining({
+          sysparm_fields: expect.stringContaining("script"),
+        }),
+      })
+    );
+    expect(result.success).toBe(true);
+    expect(result.data.self_link).toBe(
+      `https://example.service-now.com/sysauto_script.do?sys_id=${jobSysId}`
+    );
+  });
+
+  it("get_scheduled_job rejects invalid sys_id", async () => {
+    const { handlers } = setup();
+
+    const result = (await handlers.get_scheduled_job({
+      sys_id: "not-a-sys-id",
+    })) as { success: boolean; error: { code: string } };
+
+    expect(result.success).toBe(false);
+    expect(result.error.code).toBe("VALIDATION_ERROR");
+  });
+});

--- a/tests/unit/tools/scheduledJobs.test.ts
+++ b/tests/unit/tools/scheduledJobs.test.ts
@@ -86,7 +86,7 @@ describe("registerScheduledJobTools", () => {
       expect.objectContaining({
         params: expect.objectContaining({
           sysparm_query:
-            "nameLIKEMonthly^scriptCONTAINSOpen Site Openings^active=true^ORDERBYDESCsys_updated_on",
+            "nameLIKEMonthly^scriptLIKEOpen Site Openings^active=true^ORDERBYDESCsys_updated_on",
           sysparm_limit: 20,
           sysparm_offset: 0,
         }),


### PR DESCRIPTION
## Summary

Adds two read-only MCP tools for inspecting Scheduled Script Executions (`sysauto_script`). These are useful for tracing background automations such as monthly incident generators (e.g. finding the job that creates a "Monthly Review Reminder" incident on the 1st of each month).

## Tools

- **`search_scheduled_jobs`** — paginated search filtered by:
  - `name` (LIKE)
  - `script_contains` (CONTAINS over the script body — handy for locating jobs by group name, table name, or short description)
  - `run_as` (validated 32-char sys_id)
  - `active` (boolean)
  - `run_type` (e.g. `monthly`, `daily`)
  - `limit` / `offset`
- **`get_scheduled_job`** — fetches a single `sysauto_script` record by `sys_id`, returning the full script body and condition.

## Security

- `run_as` and `sys_id` inputs are validated against the existing 32-hex `SYS_ID_REGEX`.
- Query values are sanitized via the shared `sanitizeValue` helper.
- Identity is enforced by the existing per-user OAuth bearer token — these tools surface only what the caller's ServiceNow user is permitted to read.
- Tools are read-only; no insert/update/delete paths are added.

## Tests

- New unit tests in `tests/unit/tools/scheduledJobs.test.ts` cover query construction, validation rejection paths, and self_link assembly.
- Registry test updated to mock the new registration.
- All 350 tests pass; coverage thresholds maintained (`scheduledJobs.ts` at 98.85% line coverage).

## Docs

- New page: `docs/tools/scheduled-jobs.md`.
- Master tool index updated (36 → 38).
