### PR TITLE
Expand scheduled jobs tools to cover all sysauto subclasses

### DIFF
--- a/docs/tools/scheduled-jobs.md
+++ b/docs/tools/scheduled-jobs.md
@@ -2,19 +2,28 @@
 
 # Scheduled Jobs Tools (2)
 
-Read-only tools for inspecting Scheduled Script Executions (`sysauto_script`) — useful for tracing background automations such as monthly incident generators.
+Read-only tools for inspecting Scheduled Jobs — the parent `sysauto` table and every subclass that appears in the **System Definition → Scheduled Jobs** list:
+
+- `sysauto_script` — Scheduled Script Executions
+- `sysauto_template` — Scheduled Record Generators (e.g. monthly incident creators driven by a `sys_template`)
+- `sysauto_report` — Scheduled report deliveries
+- `sysauto_import` — Scheduled data imports
+- ...and any other subclass of `sysauto`
+
+`self_link` is built from the record's `sys_class_name`, so each link opens the correct subclass form.
 
 ## `search_scheduled_jobs`
 
-Search Scheduled Script Executions with filters. Returns a paginated summary list (script body excluded).
+Search the parent `sysauto` table (covers all subclasses). Returns a paginated summary list.
 
 | Parameter | Type | Required | Description |
 |---|---|---|---|
 | `name` | string | No | Job name LIKE filter |
-| `script_contains` | string | No | Match jobs whose script body contains this substring (LIKE) |
+| `script_contains` | string | No | Match `sysauto_script` jobs whose script body contains this substring (LIKE). Only applies to Scheduled Script Executions. |
 | `run_as` | string | No | Run-as user `sys_id` (32 hex chars) |
 | `active` | boolean | No | Filter by active flag |
 | `run_type` | string | No | e.g. `periodically`, `monthly`, `weekly`, `daily`, `on_demand` |
+| `sys_class_name` | string | No | Restrict to a subclass, e.g. `sysauto_script`, `sysauto_template`, `sysauto_report`, `sysauto_import` |
 | `limit` | number | No | 1-100, default 20 |
 | `offset` | number | No | Pagination offset, default 0 |
 
@@ -22,13 +31,13 @@ Search Scheduled Script Executions with filters. Returns a paginated summary lis
 
 ## `get_scheduled_job`
 
-Get full details of a Scheduled Script Execution by `sys_id`, including the `script` body and `condition`.
+Get full details of any Scheduled Job by `sys_id`. The record is fetched via the `sysauto` parent table without a `sysparm_fields` restriction, so all columns defined on the record's actual subclass are returned (e.g. `script`/`condition` for `sysauto_script`, `template`/`table` for `sysauto_template`).
 
 | Parameter | Type | Required | Description |
 |---|---|---|---|
 | `sys_id` | string | Yes | Scheduled job `sys_id` (32 hex chars) |
 
-**Returns**: The full job record plus `self_link`.
+**Returns**: The full job record plus `self_link` (built from `sys_class_name`).
 
 ---
 

--- a/docs/tools/scheduled-jobs.md
+++ b/docs/tools/scheduled-jobs.md
@@ -19,7 +19,7 @@ Search the parent `sysauto` table (covers all subclasses). Returns a paginated s
 | Parameter | Type | Required | Description |
 |---|---|---|---|
 | `name` | string | No | Job name LIKE filter |
-| `script_contains` | string | No | Match `sysauto_script` jobs whose script body contains this substring (LIKE). Only applies to Scheduled Script Executions. |
+| `script_contains` | string | No | Match Scheduled Script Executions whose script body contains this substring (LIKE). Automatically scopes the search to `sys_class_name=sysauto_script` because the `script` column only exists on that subclass; passing a different `sys_class_name` together with `script_contains` is rejected. |
 | `run_as` | string | No | Run-as user `sys_id` (32 hex chars) |
 | `active` | boolean | No | Filter by active flag |
 | `run_type` | string | No | e.g. `periodically`, `monthly`, `weekly`, `daily`, `on_demand` |

--- a/src/tools/scheduledJobs.ts
+++ b/src/tools/scheduledJobs.ts
@@ -16,6 +16,12 @@ type WrapHandler = <T>(
   isError?: boolean;
 }>;
 
+// Parent `sysauto` table backs the "Scheduled Jobs" list and is extended by
+// every subclass: sysauto_script, sysauto_template (record generators),
+// sysauto_report, sysauto_import, etc. Querying the parent surfaces all of
+// them in one call.
+const PARENT_TABLE = "sysauto";
+
 const SUMMARY_FIELDS = [
   "sys_id",
   "name",
@@ -32,20 +38,17 @@ const SUMMARY_FIELDS = [
   "sys_updated_on",
 ].join(",");
 
-const DETAIL_FIELDS = [
-  SUMMARY_FIELDS,
-  "script",
-  "condition",
-  "description",
-  "sys_created_on",
-  "sys_created_by",
-  "sys_updated_by",
-].join(",");
-
 interface ScheduledJobRecord {
   sys_id: string;
   name?: string;
+  sys_class_name?: string;
   [key: string]: unknown;
+}
+
+function resolveTable(record: { sys_class_name?: string }): string {
+  return record.sys_class_name && record.sys_class_name.length > 0
+    ? record.sys_class_name
+    : PARENT_TABLE;
 }
 
 export function registerScheduledJobTools(
@@ -55,7 +58,7 @@ export function registerScheduledJobTools(
   // search_scheduled_jobs
   server.tool(
     "search_scheduled_jobs",
-    "Search Scheduled Script Executions (sysauto_script). Useful for finding background jobs that create or update records on a schedule (e.g. monthly incident generators). Returns a paginated summary list.",
+    "Search Scheduled Jobs (sysauto and all subclasses: sysauto_script, sysauto_template, sysauto_report, sysauto_import, etc.). Useful for finding background automations that create or update records on a schedule (e.g. monthly incident generators built as Scheduled Record Generators or Scheduled Script Executions). Returns a paginated summary list.",
     {
       name: z
         .string()
@@ -65,7 +68,7 @@ export function registerScheduledJobTools(
         .string()
         .optional()
         .describe(
-          "Filter to jobs whose script body CONTAINS this substring (e.g. a table name, group name, or short description)"
+          "Filter to sysauto_script jobs whose script body CONTAINS this substring (only matches Scheduled Script Executions)"
         ),
       run_as: z
         .string()
@@ -80,6 +83,12 @@ export function registerScheduledJobTools(
         .optional()
         .describe(
           "Filter by run_type (e.g. 'periodically', 'monthly', 'weekly', 'daily', 'on_demand')"
+        ),
+      sys_class_name: z
+        .string()
+        .optional()
+        .describe(
+          "Filter by subclass table (e.g. 'sysauto_script', 'sysauto_template', 'sysauto_report', 'sysauto_import')"
         ),
       limit: z
         .number()
@@ -104,6 +113,7 @@ export function registerScheduledJobTools(
           run_as?: string;
           active?: boolean;
           run_type?: string;
+          sys_class_name?: string;
           limit: number;
           offset: number;
         }
@@ -136,12 +146,17 @@ export function registerScheduledJobTools(
         if (args.run_type) {
           queryParts.push(`run_type=${sanitizeValue(args.run_type)}`);
         }
+        if (args.sys_class_name) {
+          queryParts.push(
+            `sys_class_name=${sanitizeValue(args.sys_class_name)}`
+          );
+        }
 
         queryParts.push("ORDERBYDESCsys_updated_on");
 
         const { data, headers } = await ctx.snClient.get<
           ServiceNowListResponse<ScheduledJobRecord>
-        >("/api/now/table/sysauto_script", {
+        >(`/api/now/table/${PARENT_TABLE}`, {
           params: {
             sysparm_query: queryParts.join("^"),
             sysparm_limit: args.limit,
@@ -156,7 +171,7 @@ export function registerScheduledJobTools(
             ...r,
             self_link: buildRecordUrl(
               ctx.instanceUrl,
-              "sysauto_script",
+              resolveTable(r),
               r.sys_id
             ),
           })),
@@ -173,7 +188,7 @@ export function registerScheduledJobTools(
   // get_scheduled_job
   server.tool(
     "get_scheduled_job",
-    "Get full details of a Scheduled Script Execution (sysauto_script) by sys_id, including the script body and condition.",
+    "Get full details of a Scheduled Job (sysauto and all subclasses) by sys_id. Returns all fields for the record's class — including script/condition for sysauto_script and template/table for sysauto_template (Scheduled Record Generators).",
     {
       sys_id: z
         .string()
@@ -191,13 +206,11 @@ export function registerScheduledJobTools(
           };
         }
 
+        // Fetch from the parent table without sysparm_fields so the API
+        // returns every column defined on the record's actual subclass.
         const { data } = await ctx.snClient.get<
           ServiceNowSingleResponse<ScheduledJobRecord>
-        >(`/api/now/table/sysauto_script/${args.sys_id}`, {
-          params: {
-            sysparm_fields: DETAIL_FIELDS,
-          },
-        });
+        >(`/api/now/table/${PARENT_TABLE}/${args.sys_id}`);
 
         return {
           success: true,
@@ -205,7 +218,7 @@ export function registerScheduledJobTools(
             ...data.result,
             self_link: buildRecordUrl(
               ctx.instanceUrl,
-              "sysauto_script",
+              resolveTable(data.result),
               data.result.sys_id
             ),
           },

--- a/src/tools/scheduledJobs.ts
+++ b/src/tools/scheduledJobs.ts
@@ -68,7 +68,7 @@ export function registerScheduledJobTools(
         .string()
         .optional()
         .describe(
-          "Filter to sysauto_script jobs whose script body CONTAINS this substring (only matches Scheduled Script Executions)"
+          "Filter to Scheduled Script Executions whose script body CONTAINS this substring. Automatically scopes the search to sys_class_name='sysauto_script' since the script field only exists on that subclass."
         ),
       run_as: z
         .string()
@@ -120,6 +120,28 @@ export function registerScheduledJobTools(
       ) => {
         const queryParts: string[] = [];
 
+        // `script` only exists on the sysauto_script child table, so when the
+        // caller asks for a script substring filter we must constrain the
+        // query to that subclass — otherwise the Table API ignores the
+        // unknown column on the parent and returns unrelated jobs.
+        let effectiveSysClassName = args.sys_class_name;
+        if (args.script_contains) {
+          if (
+            effectiveSysClassName &&
+            effectiveSysClassName !== "sysauto_script"
+          ) {
+            return {
+              success: false,
+              error: {
+                code: "VALIDATION_ERROR",
+                message:
+                  "script_contains can only be used with sys_class_name='sysauto_script' (the script field does not exist on other subclasses)",
+              },
+            };
+          }
+          effectiveSysClassName = "sysauto_script";
+        }
+
         if (args.name) {
           queryParts.push(`nameLIKE${sanitizeValue(args.name)}`);
         }
@@ -146,9 +168,9 @@ export function registerScheduledJobTools(
         if (args.run_type) {
           queryParts.push(`run_type=${sanitizeValue(args.run_type)}`);
         }
-        if (args.sys_class_name) {
+        if (effectiveSysClassName) {
           queryParts.push(
-            `sys_class_name=${sanitizeValue(args.sys_class_name)}`
+            `sys_class_name=${sanitizeValue(effectiveSysClassName)}`
           );
         }
 

--- a/tests/unit/tools/scheduledJobs.test.ts
+++ b/tests/unit/tools/scheduledJobs.test.ts
@@ -63,6 +63,7 @@ describe("registerScheduledJobTools", () => {
             name: "Monthly Site Openings",
             active: "true",
             run_type: "monthly",
+            sys_class_name: "sysauto_script",
           },
         ],
       },
@@ -82,7 +83,7 @@ describe("registerScheduledJobTools", () => {
     };
 
     expect(snClient.get).toHaveBeenCalledWith(
-      "/api/now/table/sysauto_script",
+      "/api/now/table/sysauto",
       expect.objectContaining({
         params: expect.objectContaining({
           sysparm_query:
@@ -119,12 +120,51 @@ describe("registerScheduledJobTools", () => {
     });
 
     expect(snClient.get).toHaveBeenCalledWith(
-      "/api/now/table/sysauto_script",
+      "/api/now/table/sysauto",
       expect.objectContaining({
         params: expect.objectContaining({
           sysparm_query: `run_as=${runAs}^ORDERBYDESCsys_updated_on`,
         }),
       })
+    );
+  });
+
+  it("search_scheduled_jobs filters by sys_class_name and uses class for self_link", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.get.mockResolvedValue({
+      data: {
+        result: [
+          {
+            sys_id: "tmpl-sys-id-001",
+            name: "Monthly Review Reminder: Open Site Openings",
+            sys_class_name: "sysauto_template",
+          },
+        ],
+      },
+      headers: { "x-total-count": "1" },
+    });
+
+    const result = (await handlers.search_scheduled_jobs({
+      sys_class_name: "sysauto_template",
+      limit: 20,
+      offset: 0,
+    })) as {
+      success: boolean;
+      data: { sys_id: string; self_link: string }[];
+    };
+
+    expect(snClient.get).toHaveBeenCalledWith(
+      "/api/now/table/sysauto",
+      expect.objectContaining({
+        params: expect.objectContaining({
+          sysparm_query:
+            "sys_class_name=sysauto_template^ORDERBYDESCsys_updated_on",
+        }),
+      })
+    );
+    expect(result.data[0].self_link).toBe(
+      "https://example.service-now.com/sysauto_template.do?sys_id=tmpl-sys-id-001"
     );
   });
 
@@ -151,6 +191,7 @@ describe("registerScheduledJobTools", () => {
           sys_id: jobSysId,
           name: "PDI Monthly Reminder",
           script: "// create incident",
+          sys_class_name: "sysauto_script",
         },
       },
       headers: {},
@@ -161,16 +202,38 @@ describe("registerScheduledJobTools", () => {
     })) as { success: boolean; data: { self_link: string } };
 
     expect(snClient.get).toHaveBeenCalledWith(
-      `/api/now/table/sysauto_script/${jobSysId}`,
-      expect.objectContaining({
-        params: expect.objectContaining({
-          sysparm_fields: expect.stringContaining("script"),
-        }),
-      })
+      `/api/now/table/sysauto/${jobSysId}`
     );
     expect(result.success).toBe(true);
     expect(result.data.self_link).toBe(
       `https://example.service-now.com/sysauto_script.do?sys_id=${jobSysId}`
+    );
+  });
+
+  it("get_scheduled_job builds self_link from sys_class_name for record generators", async () => {
+    const { handlers, snClient } = setup();
+    const jobSysId = "5fef879647f4b6d4718d8a12736d43fd";
+
+    snClient.get.mockResolvedValue({
+      data: {
+        result: {
+          sys_id: jobSysId,
+          name: "Monthly Review Reminder: Open Site Openings",
+          sys_class_name: "sysauto_template",
+        },
+      },
+      headers: {},
+    });
+
+    const result = (await handlers.get_scheduled_job({
+      sys_id: jobSysId,
+    })) as { success: boolean; data: { self_link: string } };
+
+    expect(snClient.get).toHaveBeenCalledWith(
+      `/api/now/table/sysauto/${jobSysId}`
+    );
+    expect(result.data.self_link).toBe(
+      `https://example.service-now.com/sysauto_template.do?sys_id=${jobSysId}`
     );
   });
 

--- a/tests/unit/tools/scheduledJobs.test.ts
+++ b/tests/unit/tools/scheduledJobs.test.ts
@@ -87,7 +87,7 @@ describe("registerScheduledJobTools", () => {
       expect.objectContaining({
         params: expect.objectContaining({
           sysparm_query:
-            "nameLIKEMonthly^scriptLIKEOpen Site Openings^active=true^ORDERBYDESCsys_updated_on",
+            "nameLIKEMonthly^scriptLIKEOpen Site Openings^active=true^sys_class_name=sysauto_script^ORDERBYDESCsys_updated_on",
           sysparm_limit: 20,
           sysparm_offset: 0,
         }),
@@ -177,6 +177,21 @@ describe("registerScheduledJobTools", () => {
       offset: 0,
     })) as { success: boolean; error: { code: string } };
 
+    expect(result.success).toBe(false);
+    expect(result.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("search_scheduled_jobs rejects script_contains combined with non-script sys_class_name", async () => {
+    const { handlers, snClient } = setup();
+
+    const result = (await handlers.search_scheduled_jobs({
+      script_contains: "anything",
+      sys_class_name: "sysauto_template",
+      limit: 20,
+      offset: 0,
+    })) as { success: boolean; error: { code: string } };
+
+    expect(snClient.get).not.toHaveBeenCalled();
     expect(result.success).toBe(false);
     expect(result.error.code).toBe("VALIDATION_ERROR");
   });


### PR DESCRIPTION
## Summary

Switches `search_scheduled_jobs` and `get_scheduled_job` from querying `sysauto_script` to the parent `sysauto` table so every record that appears under **System Definition → Scheduled Jobs** is returned, not just Scheduled Script Executions.

This includes:
- `sysauto_script` — Scheduled Script Executions
- `sysauto_template` — Scheduled Record Generators (e.g. monthly incident creators driven by a `sys_template`)
- `sysauto_report` — Scheduled report deliveries
- `sysauto_import` — Scheduled data imports

## Motivation

A real-world scenario surfaced the gap: tracing the monthly auto-created "Monthly Review Reminder: Open Site Openings" incident assigned to *IT - PDI Support*. The job (`5fef879647f4b6d4718d8a12736d43fd`) is a `sysauto_template` Scheduled Record Generator and was invisible to the previous tool, which only queried `sysauto_script`.

## Changes

- `search_scheduled_jobs` now hits `/api/now/table/sysauto` and accepts an optional `sys_class_name` filter (e.g. `sysauto_template`).
- `get_scheduled_job` fetches via `sysauto` without a `sysparm_fields` restriction, so subclass-specific columns (`template`/`table` for record generators, `script`/`condition` for script executions, etc.) are returned.
- `self_link` is built from each record's `sys_class_name` so the link opens the correct subclass form.
- Tool descriptions, docs (`docs/tools/scheduled-jobs.md`), and unit tests updated. Two new tests cover `sysauto_template` search and get.

## Validation

- `npm run build` — clean
- `npm test` — 352/352 passing (7/7 in `scheduledJobs.test.ts`)