### PR TITLE
fix: set isError: true when tool returns success: false

### DIFF
--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -92,6 +92,12 @@ export function registerAllTools(
         const ctx = await getContext(extra);
         const startTime = Date.now();
         const result = await handler(ctx, args);
+
+        // Check for logical errors (e.g., { success: false, error: ... })
+        if (result && typeof result === 'object' && 'success' in result && (result as any).success === false) {
+          return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }], isError: true };
+        }
+
         const duration = Date.now() - startTime;
         logger.info(
           { userName: ctx.userName, duration },


### PR DESCRIPTION
## Summary

When a tool handler returns a logical error (e.g., `{ success: false, error: { code: "NOT_FOUND", ... } }`), the MCP `CallToolResult` wrapper now correctly sets `isError: true` so the client LLM properly interprets it as a failure.

## Changes

- Added check in `wrapHandler` to detect when `result.success === false`
- Returns `{ isError: true }` for logical errors, matching MCP specification
- Preserves existing error handling for thrown exceptions

## Testing

- Tested with a tool that returns `{ success: false, error: { code: "NOT_FOUND", message: "..." } }`
- Verified that `isError: true` is now set in the MCP response
- Confirmed that successful responses (`success: true`) still return `isError: false` (omitted)

Fixes #61