### PR TITLE
fix: add limit parameter to get_my_tasks and get_my_approvals

### DIFF
--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -28,8 +28,9 @@ export function registerTaskTools(
     "Get all open tasks assigned to the authenticated user across all task types (incidents, requests, changes, etc.).",
     {
       offset: z.number().int().min(0).default(0).describe("Starting offset for continuation when previous response was truncated"),
+      limit: z.number().int().min(1).max(100).default(10).describe("Maximum number of records to return per page (1-100)"),
     },
-    wrapHandler(async (ctx: ToolContext, args: { offset: number }) => {
+    wrapHandler(async (ctx: ToolContext, args: { offset: number; limit: number }) => {
       const { results, totalCount, truncated } = await paginateAll<Task>(
         async (limit, offset) => {
           const { data, headers } = await ctx.snClient.get<ServiceNowListResponse<Task>>(
@@ -49,7 +50,7 @@ export function registerTaskTools(
             totalCount: parseInt(headers["x-total-count"] || "0", 10),
           };
         },
-        { limit: 100, maxPages: 5, startOffset: args.offset }
+        { limit: args.limit, maxPages: 5, startOffset: args.offset }
       );
 
       return {
@@ -74,8 +75,9 @@ export function registerTaskTools(
     "Get pending approvals for the authenticated user.",
     {
       offset: z.number().int().min(0).default(0).describe("Starting offset for continuation when previous response was truncated"),
+      limit: z.number().int().min(1).max(100).default(10).describe("Maximum number of records to return per page (1-100)"),
     },
-    wrapHandler(async (ctx: ToolContext, args: { offset: number }) => {
+    wrapHandler(async (ctx: ToolContext, args: { offset: number; limit: number }) => {
       const { results, totalCount, truncated } = await paginateAll<Approval>(
         async (limit, offset) => {
           const { data, headers } = await ctx.snClient.get<ServiceNowListResponse<Approval>>(
@@ -95,7 +97,7 @@ export function registerTaskTools(
             totalCount: parseInt(headers["x-total-count"] || "0", 10),
           };
         },
-        { limit: 100, maxPages: 5, startOffset: args.offset }
+        { limit: args.limit, maxPages: 5, startOffset: args.offset }
       );
 
       return {


### PR DESCRIPTION
## Summary

Add a configurable `limit` parameter (1-100, default 10) to both `get_my_tasks` and `get_my_approvals` tools to prevent excessive context bloat.

## Problem

Previously, both tools unconditionally fetched up to 500 records (100 per page × 5 pages), wasting tokens and increasing latency. For an LLM context window, returning 500 full JSON records is excessive.

## Changes

- Added `limit` parameter to Zod schemas for both tools
- Parameter defaults to 10 (was hardcoded to 100)
- Parameter range: 1-100 records per page
- Updated `paginateAll` calls to use `args.limit` instead of hardcoded `100`

## Testing

- Verified that `limit` parameter is properly validated (1-100 range)
- Confirmed default value of 10 works correctly
- Tested with various limit values (1, 10, 50, 100)
- Confirmed `maxPages: 5` still applies (so max total = limit × 5)

Fixes #58