### PR TITLE
fix: remove raw response body from error details

### DIFF
--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -64,8 +64,7 @@ export function mapServiceNowError(
       }
       return createToolError(
         "UNEXPECTED_ERROR",
-        "An unexpected error occurred.",
-        responseBody
+        "An unexpected error occurred."
       );
   }
 }


### PR DESCRIPTION
## Summary

Remove the raw `responseBody` from client-facing error objects to prevent sensitive internal system details from leaking to MCP clients/LLMs.

## Problem

The `mapServiceNowError` function was passing the raw `responseBody` to `createToolError` as the `details` field. ServiceNow error responses often contain:
- Stack traces
- Internal table names
- SQL fragments
- Other sensitive system details

Exposing this information to MCP clients/LLMs is a security risk.

## Changes

- Removed `responseBody` parameter from the `createToolError` call in the default case of `mapServiceNowError`
- Error responses now only contain the error code, message, and reference ID
- No sensitive internal details are exposed to clients

## Testing

- Verified that error responses no longer contain `responseBody` in the `details` field
- Confirmed that error codes and messages are still properly set
- Tested with various HTTP status codes (400, 401, 403, 404, 429, 500+)

Fixes #37