### PR TITLE
fix: Eliminate unnecessary extra API call when results align with page size (#66)

### DIFF
--- a/src/paginator.ts
+++ b/src/paginator.ts
@@ -1,0 +1,82 @@
+/**
+ * Fixed Paginator - Eliminates unnecessary extra API call
+ * 
+ * Bug: When results perfectly align with page size, the paginator
+ * makes an extra API call that returns empty results.
+ * 
+ * Fix: Track total count and check if we've reached it before
+ * making the next call.
+ */
+
+export interface PaginatorConfig {
+  pageSize: number;
+  maxItems?: number;
+}
+
+export interface PageResult<T> {
+  items: T[];
+  total: number;
+  page: number;
+  pageSize: number;
+  hasMore: boolean;
+}
+
+export class Paginator<T> {
+  private page = 0;
+  private fetchedItems = 0;
+  private total: number | null = null;
+
+  constructor(
+    private fetcher: (page: number, pageSize: number) => Promise<{ items: T[]; total: number }>,
+    private config: PaginatorConfig
+  ) {}
+
+  async next(): Promise<PageResult<T> | null> {
+    // FIX: Check if we already fetched all items before making another API call
+    if (this.total !== null && this.fetchedItems >= this.total) {
+      return null;
+    }
+
+    // FIX: Also respect maxItems limit
+    if (this.config.maxItems && this.fetchedItems >= this.config.maxItems) {
+      return null;
+    }
+
+    const pageSize = this.config.maxItems
+      ? Math.min(this.config.pageSize, this.config.maxItems - this.fetchedItems)
+      : this.config.pageSize;
+
+    const result = await this.fetcher(this.page, pageSize);
+    
+    // Update total from API response
+    this.total = result.total;
+    this.fetchedItems += result.items.length;
+    this.page++;
+
+    const hasMore = this.fetchedItems < this.total &&
+      (!this.config.maxItems || this.fetchedItems < this.config.maxItems);
+
+    return {
+      items: result.items,
+      total: result.total,
+      page: this.page,
+      pageSize,
+      hasMore,
+    };
+  }
+
+  async all(): Promise<T[]> {
+    const all: T[] = [];
+    let result: PageResult<T> | null;
+    while ((result = await this.next()) !== null) {
+      all.push(...result.items);
+    }
+    return all;
+  }
+
+  reset(): void {
+    this.page = 0;
+    this.fetchedItems = 0;
+    this.total = null;
+  }
+}

--- a/tests/paginator.test.ts
+++ b/tests/paginator.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Paginator } from '../src/paginator';
+
+describe('Paginator', () => {
+  it('should not make extra call when results align with page size', async () => {
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce({ items: [1, 2, 3], total: 3 })
+      .mockResolvedValueOnce({ items: [], total: 3 });
+
+    const paginator = new Paginator<number>(fetcher, { pageSize: 3 });
+    
+    const page1 = await paginator.next();
+    expect(page1?.items).toEqual([1, 2, 3]);
+    expect(page1?.hasMore).toBe(false);
+    
+    // Should return null without making another API call
+    const page2 = await paginator.next();
+    expect(page2).toBeNull();
+    
+    // Should only have called fetcher once
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handle multiple pages correctly', async () => {
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce({ items: [1, 2], total: 4 })
+      .mockResolvedValueOnce({ items: [3, 4], total: 4 });
+
+    const paginator = new Paginator<number>(fetcher, { pageSize: 2 });
+    
+    const p1 = await paginator.next();
+    expect(p1?.hasMore).toBe(true);
+    
+    const p2 = await paginator.next();
+    expect(p2?.hasMore).toBe(false);
+    expect(p2?.items).toEqual([3, 4]);
+    
+    const p3 = await paginator.next();
+    expect(p3).toBeNull();
+    
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it('should respect maxItems limit', async () => {
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce({ items: [1, 2, 3, 4, 5], total: 10 });
+
+    const paginator = new Paginator<number>(fetcher, { pageSize: 5, maxItems: 3 });
+    
+    const page = await paginator.next();
+    expect(page?.items).toEqual([1, 2, 3]);
+    
+    const next = await paginator.next();
+    expect(next).toBeNull();
+  });
+
+  it('should collect all items', async () => {
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce({ items: [1, 2], total: 4 })
+      .mockResolvedValueOnce({ items: [3, 4], total: 4 });
+
+    const paginator = new Paginator<number>(fetcher, { pageSize: 2 });
+    const all = await paginator.all();
+    expect(all).toEqual([1, 2, 3, 4]);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Fix for #66

- Added total count tracking to prevent unnecessary next-page calls
- Fixed edge case where exact-fit results triggered one extra empty call
- Added maxItems support
- Added comprehensive tests

Wallet: zp6