### PR TITLE
Add flow logs tools for Flow Designer execution history

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Comprehensive documentation lives in [`docs/`](./docs/README.md):
 - **[Architecture](./docs/architecture/README.md)** — System design, session lifecycle, request flow, Redis schema
 - **[Authentication](./docs/auth/README.md)** — OAuth flow, token storage, refresh
 - **[Security](./docs/security/README.md)** — Identity enforcement, input validation, rate limiting, error handling
-- **[Tools (35)](./docs/tools/README.md)** — All tools: incidents, change requests, knowledge, update sets, and more
+- **[Tools (40)](./docs/tools/README.md)** — All tools: incidents, change requests, knowledge, update sets, scheduled jobs, flow logs, and more
 - **[Resources (5)](./docs/resources/README.md)** — MCP resources for direct record access
 - **[Prompts (7)](./docs/prompts/README.md)** — Guided workflows for incidents, change requests, knowledge, and catalog
 - **[HTTP API](./docs/api/README.md)** — Endpoints and client configuration

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -1,6 +1,6 @@
 [docs](../README.md) / tools
 
-# Tools (38)
+# Tools (40)
 
 All MCP tools provided by the server, grouped by domain.
 
@@ -46,6 +46,8 @@ All MCP tools provided by the server, grouped by domain.
 | 36 | `create_update_set` | [Update Sets](./update-sets.md) | Create a new update set |
 | 37 | `search_scheduled_jobs` | [Scheduled Jobs](./scheduled-jobs.md) | Search Scheduled Script Executions |
 | 38 | `get_scheduled_job` | [Scheduled Jobs](./scheduled-jobs.md) | Get a Scheduled Script Execution by sys_id |
+| 39 | `search_flow_executions` | [Flow Logs](./flow-logs.md) | Search Flow Designer execution history |
+| 40 | `get_flow_execution` | [Flow Logs](./flow-logs.md) | Get a flow execution + its step log by sys_id |
 
 ## Common Patterns
 

--- a/docs/tools/flow-logs.md
+++ b/docs/tools/flow-logs.md
@@ -1,0 +1,48 @@
+[docs](../README.md) / [tools](./README.md) / flow-logs
+
+# Flow Logs Tools (2)
+
+Read-only tools for inspecting **Flow Designer execution history**:
+
+- `sys_flow_context` — one record per flow, subflow, or action run (name, state, timing, trigger record)
+- `sys_flow_log` — the step-by-step engine log entries for a run, joined back via `sys_flow_log.context = sys_flow_context.sys_id`
+
+Typical workflow: find the run with `search_flow_executions` (often filtered to `errors_only`), then drill into it with `get_flow_execution` to read the step log and diagnose the failure.
+
+`self_link` is built for the `sys_flow_context` record and for each `sys_flow_log` entry.
+
+## `search_flow_executions`
+
+Search the `sys_flow_context` table. Returns a paginated summary list ordered by most recently started (`ORDERBYDESCstarted`).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `flow_name` | string | No | Flow/subflow/action name LIKE filter |
+| `state` | string | No | Execution state token, e.g. `COMPLETE`, `ERROR`, `IN_PROGRESS`, `WAITING`, `CANCELLED` |
+| `errors_only` | boolean | No | Convenience filter for failed runs (`state=ERROR`). Rejected if combined with an explicit `state`. |
+| `flow` | string | No | Flow definition `sys_id` (`sys_hub_flow`, 32 hex chars) |
+| `source_table` | string | No | Table of the triggering record |
+| `source_record` | string | No | `sys_id` of the triggering record (32 hex chars) |
+| `started_by` | string | No | `sys_id` of the user who triggered the run (32 hex chars) |
+| `started_after` | string | No | Only runs started on/after this date. `YYYY-MM-DD` or ISO 8601 (with timezone) |
+| `started_before` | string | No | Only runs started on/before this date. `YYYY-MM-DD` or ISO 8601 (with timezone) |
+| `limit` | number | No | 1-100, default 20 |
+| `offset` | number | No | Pagination offset, default 0 |
+
+**Returns**: Run summaries with `sys_id`, `name`, `state`, `started`, `completed`, `flow`, `source_table`, `source_record`, `started_by`, `type`, `sys_created_on`, `sys_updated_on`, and `self_link`, plus pagination `metadata`.
+
+## `get_flow_execution`
+
+Get full details of one flow execution by `sys_id`. The `sys_flow_context` record is fetched without a `sysparm_fields` restriction so all columns are returned; by default the run's `sys_flow_log` step entries are fetched too, oldest first.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `sys_id` | string | Yes | Flow execution context `sys_id` (32 hex chars) |
+| `include_logs` | boolean | No | Include `sys_flow_log` step entries (default `true`; set `false` for just the context record) |
+| `log_limit` | number | No | Max log entries returned, oldest first. 1-1000, default 200 |
+
+**Returns**: The full context record plus `self_link`. When `include_logs` is true, a `logs` array (`sys_id`, `level`, `message`, `source`, `sys_created_on`, `self_link` per entry) and `log_metadata` (`total_count`, `returned_count`, `truncated`) so the caller can tell when the log was capped by `log_limit`.
+
+---
+
+**See also**: [Scheduled Jobs](./scheduled-jobs.md) · [Input Validation](../security/input-validation.md)

--- a/src/tools/flowLogs.ts
+++ b/src/tools/flowLogs.ts
@@ -1,0 +1,345 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { ToolContext } from "./registry.js";
+import { buildRecordUrl } from "./registry.js";
+import type {
+  ServiceNowListResponse,
+  ServiceNowSingleResponse,
+} from "../servicenow/types.js";
+import { sanitizeValue } from "../servicenow/queryBuilder.js";
+import { validateSysId, normalizeDateBoundary } from "../utils/validators.js";
+
+type WrapHandler = <T>(
+  handler: (ctx: ToolContext, args: T) => Promise<unknown>
+) => (args: T) => Promise<{
+  content: { type: "text"; text: string }[];
+  isError?: boolean;
+}>;
+
+// Flow Designer execution history. Each `sys_flow_context` row is one run of a
+// flow, subflow, or action; the step-by-step engine output for that run lives
+// in `sys_flow_log`, joined back via sys_flow_log.context = sys_flow_context.sys_id.
+const CONTEXT_TABLE = "sys_flow_context";
+const LOG_TABLE = "sys_flow_log";
+
+const CONTEXT_SUMMARY_FIELDS = [
+  "sys_id",
+  "name",
+  "state",
+  "started",
+  "completed",
+  "flow",
+  "source_table",
+  "source_record",
+  "started_by",
+  "type",
+  "sys_created_on",
+  "sys_updated_on",
+].join(",");
+
+const LOG_SUMMARY_FIELDS = [
+  "sys_id",
+  "level",
+  "message",
+  "source",
+  "sys_created_on",
+].join(",");
+
+interface FlowContextRecord {
+  sys_id: string;
+  name?: string;
+  state?: string;
+  [key: string]: unknown;
+}
+
+interface FlowLogRecord {
+  sys_id: string;
+  level?: string;
+  message?: string;
+  [key: string]: unknown;
+}
+
+export function registerFlowLogTools(
+  server: McpServer,
+  wrapHandler: WrapHandler
+): void {
+  // search_flow_executions
+  server.tool(
+    "search_flow_executions",
+    "Search Flow Designer execution history (sys_flow_context) — one record per flow, subflow, or action run. Use this to find recent or failed flow runs (e.g. a flow that errored when an incident was created), then drill into a run with get_flow_execution to read its step-by-step log. Returns a paginated summary list ordered by most recently started.",
+    {
+      flow_name: z
+        .string()
+        .optional()
+        .describe("Filter by flow/subflow/action name (LIKE match)"),
+      state: z
+        .string()
+        .optional()
+        .describe(
+          "Filter by execution state token, e.g. 'COMPLETE', 'ERROR', 'IN_PROGRESS', 'WAITING', 'CANCELLED'"
+        ),
+      errors_only: z
+        .boolean()
+        .optional()
+        .describe(
+          "Convenience filter for failed runs (state=ERROR). Cannot be combined with an explicit state."
+        ),
+      flow: z
+        .string()
+        .optional()
+        .describe(
+          "Filter by flow definition sys_id (sys_hub_flow, 32 hex chars)"
+        ),
+      source_table: z
+        .string()
+        .optional()
+        .describe("Filter by the table of the triggering record"),
+      source_record: z
+        .string()
+        .optional()
+        .describe(
+          "Filter by the sys_id of the triggering record (32 hex chars)"
+        ),
+      started_by: z
+        .string()
+        .optional()
+        .describe(
+          "Filter by the sys_id of the user who triggered the run (32 hex chars)"
+        ),
+      started_after: z
+        .string()
+        .optional()
+        .describe(
+          "Only runs started on/after this date. YYYY-MM-DD or ISO 8601 (with timezone)."
+        ),
+      started_before: z
+        .string()
+        .optional()
+        .describe(
+          "Only runs started on/before this date. YYYY-MM-DD or ISO 8601 (with timezone)."
+        ),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .default(20)
+        .describe("Maximum results"),
+      offset: z
+        .number()
+        .int()
+        .min(0)
+        .default(0)
+        .describe("Result offset for pagination"),
+    },
+    wrapHandler(
+      async (
+        ctx: ToolContext,
+        args: {
+          flow_name?: string;
+          state?: string;
+          errors_only?: boolean;
+          flow?: string;
+          source_table?: string;
+          source_record?: string;
+          started_by?: string;
+          started_after?: string;
+          started_before?: string;
+          limit: number;
+          offset: number;
+        }
+      ) => {
+        // errors_only is shorthand for state=ERROR; allowing both would make
+        // the resulting query ambiguous, so reject the combination outright
+        // (mirrors the conflicting-filter guard in search_scheduled_jobs).
+        if (args.errors_only && args.state) {
+          return {
+            success: false,
+            error: {
+              code: "VALIDATION_ERROR",
+              message:
+                "errors_only cannot be combined with an explicit state (errors_only is shorthand for state=ERROR)",
+            },
+          };
+        }
+
+        const queryParts: string[] = [];
+
+        if (args.flow_name) {
+          queryParts.push(`nameLIKE${sanitizeValue(args.flow_name)}`);
+        }
+        if (args.state) {
+          queryParts.push(`state=${sanitizeValue(args.state)}`);
+        }
+        if (args.errors_only) {
+          queryParts.push("state=ERROR");
+        }
+
+        for (const [field, value] of [
+          ["flow", args.flow],
+          ["source_record", args.source_record],
+          ["started_by", args.started_by],
+        ] as const) {
+          if (!value) continue;
+          if (!validateSysId(value)) {
+            return {
+              success: false,
+              error: {
+                code: "VALIDATION_ERROR",
+                message: `${field} must be a 32-character sys_id`,
+              },
+            };
+          }
+          queryParts.push(`${field}=${value}`);
+        }
+
+        if (args.source_table) {
+          queryParts.push(
+            `source_table=${sanitizeValue(args.source_table)}`
+          );
+        }
+
+        const dateFilters: Array<
+          [string | undefined, "from" | "to", string]
+        > = [
+          [args.started_after, "from", ">="],
+          [args.started_before, "to", "<="],
+        ];
+        for (const [raw, boundary, op] of dateFilters) {
+          if (!raw) continue;
+          const normalized = normalizeDateBoundary(raw, boundary);
+          if (!normalized) {
+            return {
+              success: false,
+              error: {
+                code: "VALIDATION_ERROR",
+                message: `Invalid date for started_${boundary}: ${raw}. Use YYYY-MM-DD or ISO 8601.`,
+              },
+            };
+          }
+          queryParts.push(`started${op}${sanitizeValue(normalized)}`);
+        }
+
+        queryParts.push("ORDERBYDESCstarted");
+
+        const { data, headers } = await ctx.snClient.get<
+          ServiceNowListResponse<FlowContextRecord>
+        >(`/api/now/table/${CONTEXT_TABLE}`, {
+          params: {
+            sysparm_query: queryParts.join("^"),
+            sysparm_limit: args.limit,
+            sysparm_offset: args.offset,
+            sysparm_fields: CONTEXT_SUMMARY_FIELDS,
+          },
+        });
+
+        return {
+          success: true,
+          data: data.result.map((r) => ({
+            ...r,
+            self_link: buildRecordUrl(
+              ctx.instanceUrl,
+              CONTEXT_TABLE,
+              r.sys_id
+            ),
+          })),
+          metadata: {
+            total_count: parseInt(headers["x-total-count"] || "0", 10),
+            returned_count: data.result.length,
+            offset: args.offset,
+          },
+        };
+      }
+    )
+  );
+
+  // get_flow_execution
+  server.tool(
+    "get_flow_execution",
+    "Get full details of a single Flow Designer execution (sys_flow_context) by sys_id, including its step-by-step engine log entries from sys_flow_log (oldest first). Use this to diagnose why a specific flow run errored or stalled.",
+    {
+      sys_id: z
+        .string()
+        .describe("Flow execution context sys_id (32 hex chars)"),
+      include_logs: z
+        .boolean()
+        .default(true)
+        .describe(
+          "Include sys_flow_log step entries for this run (set false to fetch only the context record)"
+        ),
+      log_limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(1000)
+        .default(200)
+        .describe("Maximum log entries to return (oldest first)"),
+    },
+    wrapHandler(
+      async (
+        ctx: ToolContext,
+        args: {
+          sys_id: string;
+          include_logs: boolean;
+          log_limit: number;
+        }
+      ) => {
+        if (!validateSysId(args.sys_id)) {
+          return {
+            success: false,
+            error: {
+              code: "VALIDATION_ERROR",
+              message: "sys_id must be a 32-character sys_id",
+            },
+          };
+        }
+
+        const { data } = await ctx.snClient.get<
+          ServiceNowSingleResponse<FlowContextRecord>
+        >(`/api/now/table/${CONTEXT_TABLE}/${args.sys_id}`);
+
+        const result: Record<string, unknown> = {
+          ...data.result,
+          self_link: buildRecordUrl(
+            ctx.instanceUrl,
+            CONTEXT_TABLE,
+            data.result.sys_id
+          ),
+        };
+
+        if (args.include_logs) {
+          const { data: logData, headers: logHeaders } =
+            await ctx.snClient.get<ServiceNowListResponse<FlowLogRecord>>(
+              `/api/now/table/${LOG_TABLE}`,
+              {
+                params: {
+                  sysparm_query: `context=${args.sys_id}^ORDERBYsys_created_on`,
+                  sysparm_limit: args.log_limit,
+                  sysparm_fields: LOG_SUMMARY_FIELDS,
+                },
+              }
+            );
+
+          const totalLogCount = parseInt(
+            logHeaders["x-total-count"] || "0",
+            10
+          );
+          result.logs = logData.result.map((r) => ({
+            ...r,
+            self_link: buildRecordUrl(ctx.instanceUrl, LOG_TABLE, r.sys_id),
+          }));
+          result.log_metadata = {
+            total_count: totalLogCount,
+            returned_count: logData.result.length,
+            truncated: totalLogCount > logData.result.length,
+          };
+        }
+
+        return {
+          success: true,
+          data: result,
+        };
+      }
+    )
+  );
+}

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -17,6 +17,7 @@ import { registerUpdateSetTools } from "./updateSets.js";
 import { registerChangeRequestTools } from "./changeRequests.js";
 import { registerCatalogAdminTools } from "./catalogAdmin.js";
 import { registerScheduledJobTools } from "./scheduledJobs.js";
+import { registerFlowLogTools } from "./flowLogs.js";
 import { registerCatalogPrompts } from "../prompts/catalog.js";
 import { registerIncidentPrompts } from "../prompts/incidents.js";
 import { registerChangeRequestPrompts } from "../prompts/changeRequests.js";
@@ -118,6 +119,7 @@ export function registerAllTools(
   registerChangeRequestTools(server, wrapHandler);
   registerCatalogAdminTools(server, wrapHandler);
   registerScheduledJobTools(server, wrapHandler);
+  registerFlowLogTools(server, wrapHandler);
 
   registerCatalogPrompts(server);
   registerResources(server, getContext);

--- a/tests/unit/tools/flowLogs.test.ts
+++ b/tests/unit/tools/flowLogs.test.ts
@@ -1,0 +1,311 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerFlowLogTools } from "../../../src/tools/flowLogs.js";
+import type { ToolContext } from "../../../src/tools/registry.js";
+
+type WrappedHandler<T = unknown> = (args: T) => Promise<unknown>;
+
+describe("registerFlowLogTools", () => {
+  const userSysId = "abc123def456abc123def456abc12345";
+
+  function setup() {
+    const handlers: Record<string, WrappedHandler> = {};
+
+    const server = {
+      tool: vi.fn(
+        (
+          name: string,
+          _description: string,
+          _schema: unknown,
+          handler: WrappedHandler
+        ) => {
+          handlers[name] = handler;
+        }
+      ),
+    };
+
+    const snClient = {
+      get: vi.fn(),
+      patch: vi.fn(),
+      post: vi.fn(),
+    };
+
+    const ctx: ToolContext = {
+      snClient: snClient as unknown as ToolContext["snClient"],
+      instanceUrl: "https://example.service-now.com",
+      userSysId,
+      userName: "john.doe",
+      displayName: "John Doe",
+    };
+
+    const wrapHandler = <T>(
+      handler: (context: ToolContext, args: T) => Promise<unknown>
+    ) => {
+      return async (args: T) => handler(ctx, args);
+    };
+
+    registerFlowLogTools(server as never, wrapHandler);
+
+    return { handlers, snClient, server };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("search_flow_executions builds query with name, state, date bounds and returns self_link", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.get.mockResolvedValue({
+      data: {
+        result: [
+          {
+            sys_id: "ctx-sys-id-001",
+            name: "Create Incident Tasks",
+            state: "ERROR",
+          },
+        ],
+      },
+      headers: { "x-total-count": "1" },
+    });
+
+    const result = (await handlers.search_flow_executions({
+      flow_name: "Create Incident",
+      state: "ERROR",
+      started_after: "2026-05-01",
+      started_before: "2026-05-15",
+      limit: 20,
+      offset: 0,
+    })) as {
+      success: boolean;
+      data: { sys_id: string; self_link: string }[];
+      metadata: { total_count: number; returned_count: number; offset: number };
+    };
+
+    expect(snClient.get).toHaveBeenCalledWith(
+      "/api/now/table/sys_flow_context",
+      expect.objectContaining({
+        params: expect.objectContaining({
+          sysparm_query:
+            "nameLIKECreate Incident^state=ERROR^started>=2026-05-01 00:00:00^started<=2026-05-15 23:59:59^ORDERBYDESCstarted",
+          sysparm_limit: 20,
+          sysparm_offset: 0,
+        }),
+      })
+    );
+    expect(result.success).toBe(true);
+    expect(result.data[0].self_link).toBe(
+      "https://example.service-now.com/sys_flow_context.do?sys_id=ctx-sys-id-001"
+    );
+    expect(result.metadata).toEqual({
+      total_count: 1,
+      returned_count: 1,
+      offset: 0,
+    });
+  });
+
+  it("search_flow_executions maps errors_only to state=ERROR", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.get.mockResolvedValue({
+      data: { result: [] },
+      headers: { "x-total-count": "0" },
+    });
+
+    await handlers.search_flow_executions({
+      errors_only: true,
+      limit: 20,
+      offset: 0,
+    });
+
+    expect(snClient.get).toHaveBeenCalledWith(
+      "/api/now/table/sys_flow_context",
+      expect.objectContaining({
+        params: expect.objectContaining({
+          sysparm_query: "state=ERROR^ORDERBYDESCstarted",
+        }),
+      })
+    );
+  });
+
+  it("search_flow_executions accepts valid reference sys_ids", async () => {
+    const { handlers, snClient } = setup();
+    const flow = "ed72db164738b6d4718d8a12736d4339";
+    const sourceRecord = "5fef879647f4b6d4718d8a12736d43fd";
+
+    snClient.get.mockResolvedValue({
+      data: { result: [] },
+      headers: { "x-total-count": "0" },
+    });
+
+    await handlers.search_flow_executions({
+      flow,
+      source_record: sourceRecord,
+      source_table: "incident",
+      limit: 20,
+      offset: 0,
+    });
+
+    expect(snClient.get).toHaveBeenCalledWith(
+      "/api/now/table/sys_flow_context",
+      expect.objectContaining({
+        params: expect.objectContaining({
+          sysparm_query: `flow=${flow}^source_record=${sourceRecord}^source_table=incident^ORDERBYDESCstarted`,
+        }),
+      })
+    );
+  });
+
+  it("search_flow_executions rejects errors_only combined with explicit state", async () => {
+    const { handlers, snClient } = setup();
+
+    const result = (await handlers.search_flow_executions({
+      errors_only: true,
+      state: "COMPLETE",
+      limit: 20,
+      offset: 0,
+    })) as { success: boolean; error: { code: string } };
+
+    expect(snClient.get).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("search_flow_executions rejects an invalid flow sys_id", async () => {
+    const { handlers, snClient } = setup();
+
+    const result = (await handlers.search_flow_executions({
+      flow: "not-a-sys-id",
+      limit: 20,
+      offset: 0,
+    })) as { success: boolean; error: { code: string } };
+
+    expect(snClient.get).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("search_flow_executions rejects an invalid date", async () => {
+    const { handlers, snClient } = setup();
+
+    const result = (await handlers.search_flow_executions({
+      started_after: "not-a-date",
+      limit: 20,
+      offset: 0,
+    })) as { success: boolean; error: { code: string } };
+
+    expect(snClient.get).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("get_flow_execution returns the context plus its logs and a truncation flag", async () => {
+    const { handlers, snClient } = setup();
+    const ctxSysId = "0123456789abcdef0123456789abcdef";
+
+    snClient.get
+      .mockResolvedValueOnce({
+        data: {
+          result: {
+            sys_id: ctxSysId,
+            name: "Create Incident Tasks",
+            state: "ERROR",
+          },
+        },
+        headers: {},
+      })
+      .mockResolvedValueOnce({
+        data: {
+          result: [
+            {
+              sys_id: "log-sys-id-001",
+              level: "ERROR",
+              message: "Step 2 failed: undefined is not an object",
+            },
+          ],
+        },
+        headers: { "x-total-count": "5" },
+      });
+
+    const result = (await handlers.get_flow_execution({
+      sys_id: ctxSysId,
+      include_logs: true,
+      log_limit: 1,
+    })) as {
+      success: boolean;
+      data: {
+        self_link: string;
+        logs: { sys_id: string; self_link: string }[];
+        log_metadata: {
+          total_count: number;
+          returned_count: number;
+          truncated: boolean;
+        };
+      };
+    };
+
+    expect(snClient.get).toHaveBeenNthCalledWith(
+      1,
+      `/api/now/table/sys_flow_context/${ctxSysId}`
+    );
+    expect(snClient.get).toHaveBeenNthCalledWith(
+      2,
+      "/api/now/table/sys_flow_log",
+      expect.objectContaining({
+        params: expect.objectContaining({
+          sysparm_query: `context=${ctxSysId}^ORDERBYsys_created_on`,
+          sysparm_limit: 1,
+        }),
+      })
+    );
+    expect(result.success).toBe(true);
+    expect(result.data.self_link).toBe(
+      `https://example.service-now.com/sys_flow_context.do?sys_id=${ctxSysId}`
+    );
+    expect(result.data.logs[0].self_link).toBe(
+      "https://example.service-now.com/sys_flow_log.do?sys_id=log-sys-id-001"
+    );
+    expect(result.data.log_metadata).toEqual({
+      total_count: 5,
+      returned_count: 1,
+      truncated: true,
+    });
+  });
+
+  it("get_flow_execution skips the log fetch when include_logs is false", async () => {
+    const { handlers, snClient } = setup();
+    const ctxSysId = "0123456789abcdef0123456789abcdef";
+
+    snClient.get.mockResolvedValue({
+      data: { result: { sys_id: ctxSysId, name: "Create Incident Tasks" } },
+      headers: {},
+    });
+
+    const result = (await handlers.get_flow_execution({
+      sys_id: ctxSysId,
+      include_logs: false,
+      log_limit: 200,
+    })) as { success: boolean; data: Record<string, unknown> };
+
+    expect(snClient.get).toHaveBeenCalledTimes(1);
+    expect(snClient.get).toHaveBeenCalledWith(
+      `/api/now/table/sys_flow_context/${ctxSysId}`
+    );
+    expect(result.success).toBe(true);
+    expect(result.data.logs).toBeUndefined();
+    expect(result.data.log_metadata).toBeUndefined();
+  });
+
+  it("get_flow_execution rejects an invalid sys_id", async () => {
+    const { handlers, snClient } = setup();
+
+    const result = (await handlers.get_flow_execution({
+      sys_id: "not-a-sys-id",
+      include_logs: true,
+      log_limit: 200,
+    })) as { success: boolean; error: { code: string } };
+
+    expect(snClient.get).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.error.code).toBe("VALIDATION_ERROR");
+  });
+});

--- a/tests/unit/tools/registry.test.ts
+++ b/tests/unit/tools/registry.test.ts
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   registerChangeRequestTools: vi.fn(),
   registerCatalogAdminTools: vi.fn(),
   registerScheduledJobTools: vi.fn(),
+  registerFlowLogTools: vi.fn(),
   registerCatalogPrompts: vi.fn(),
   registerIncidentPrompts: vi.fn(),
   registerChangeRequestPrompts: vi.fn(),
@@ -58,6 +59,10 @@ vi.mock("../../../src/tools/catalogAdmin.js", () => ({
 
 vi.mock("../../../src/tools/scheduledJobs.js", () => ({
   registerScheduledJobTools: mocks.registerScheduledJobTools,
+}));
+
+vi.mock("../../../src/tools/flowLogs.js", () => ({
+  registerFlowLogTools: mocks.registerFlowLogTools,
 }));
 
 vi.mock("../../../src/prompts/catalog.js", () => ({
@@ -166,6 +171,7 @@ describe("registerAllTools", () => {
     mocks.registerChangeRequestTools.mockImplementation(() => {});
     mocks.registerCatalogAdminTools.mockImplementation(() => {});
     mocks.registerScheduledJobTools.mockImplementation(() => {});
+    mocks.registerFlowLogTools.mockImplementation(() => {});
     mocks.registerCatalogPrompts.mockImplementation(() => {});
     mocks.registerIncidentPrompts.mockImplementation(() => {});
     mocks.registerChangeRequestPrompts.mockImplementation(() => {});


### PR DESCRIPTION
## Summary
Adds two read-only MCP tools for Flow Designer execution history:

- `search_flow_executions` — search Flow Designer execution history
- `get_flow_execution` — get a single flow execution plus its step log by sys_id

## Changes
- New `src/tools/flowLogs.ts` implementing both tools, registered via `registerFlowLogTools` in the tool registry.
- New unit tests in `tests/unit/tools/flowLogs.test.ts`; registry test updated for the new registration.
- New `docs/tools/flow-logs.md`; updated `README.md` and `docs/tools/README.md` tool counts and listings.

## Validation
- `npm run build` — passes
- `npm test` — 362 tests passing across 33 files
- `npm run test:coverage` — thresholds passing; `flowLogs.ts` at 100% line coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)