### PR TITLE
Add CMDB read tools for health checks and migration triage

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Comprehensive documentation lives in [`docs/`](./docs/README.md):
 - **[Architecture](./docs/architecture/README.md)** — System design, session lifecycle, request flow, Redis schema
 - **[Authentication](./docs/auth/README.md)** — OAuth flow, token storage, refresh
 - **[Security](./docs/security/README.md)** — Identity enforcement, input validation, rate limiting, error handling
-- **[Tools (40)](./docs/tools/README.md)** — All tools: incidents, change requests, knowledge, update sets, scheduled jobs, flow logs, and more
+- **[Tools (46)](./docs/tools/README.md)** — All tools: incidents, change requests, knowledge, update sets, scheduled jobs, flow logs, CMDB, and more
 - **[Resources (5)](./docs/resources/README.md)** — MCP resources for direct record access
 - **[Prompts (7)](./docs/prompts/README.md)** — Guided workflows for incidents, change requests, knowledge, and catalog
 - **[HTTP API](./docs/api/README.md)** — Endpoints and client configuration

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -1,6 +1,6 @@
 [docs](../README.md) / tools
 
-# Tools (40)
+# Tools (46)
 
 All MCP tools provided by the server, grouped by domain.
 
@@ -48,6 +48,12 @@ All MCP tools provided by the server, grouped by domain.
 | 38 | `get_scheduled_job` | [Scheduled Jobs](./scheduled-jobs.md) | Get a Scheduled Script Execution by sys_id |
 | 39 | `search_flow_executions` | [Flow Logs](./flow-logs.md) | Search Flow Designer execution history |
 | 40 | `get_flow_execution` | [Flow Logs](./flow-logs.md) | Get a flow execution + its step log by sys_id |
+| 41 | `search_cis` | [CMDB](./cmdb.md) | Search CMDB CIs by class, name, source, status, last-discovered |
+| 42 | `get_ci` | [CMDB](./cmdb.md) | Get full CI record by sys_id |
+| 43 | `get_ci_relationships` | [CMDB](./cmdb.md) | Read cmdb_rel_ci for a CI (parent_of / child_of) |
+| 44 | `count_cis_by_class` | [CMDB](./cmdb.md) | Aggregate CI counts per class (whole-CMDB shape) |
+| 45 | `find_stale_cis` | [CMDB](./cmdb.md) | Find migration-skip candidate CIs by staleness signal |
+| 46 | `get_ci_ticket_references` | [CMDB](./cmdb.md) | Count incident/change/problem refs to a CI |
 
 ## Common Patterns
 

--- a/docs/tools/cmdb.md
+++ b/docs/tools/cmdb.md
@@ -1,0 +1,93 @@
+[docs](../README.md) / [tools](./README.md) / cmdb
+
+# CMDB Tools (6)
+
+Read-only tools for assessing the **Configuration Management Database** — its shape, data quality, dependency coverage, and which CIs are actually in use. Aimed at CMDB health checks and migration triage.
+
+- `cmdb_ci` — the parent CI table; every class (`cmdb_ci_server`, `cmdb_ci_db_instance`, `cmdb_ci_appl`, …) extends it, so querying the parent surfaces every CI in one call. `sys_class_name` identifies the concrete subclass.
+- `cmdb_rel_ci` — directed `parent` → `child` relationships used by dependency mapping.
+
+Reference fields (`owned_by`, `managed_by`, `location`, `support_group`, `assignment_group`) are returned as readable display values. `self_link` points at the CI's concrete subclass form when `sys_class_name` is known, falling back to `cmdb_ci` (which also resolves to the record's real class form).
+
+## `search_cis`
+
+The workhorse. Search `cmdb_ci` and every subclass with filters, ordered by most recently updated (`ORDERBYDESCsys_updated_on`).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | No | CI name LIKE filter |
+| `sys_class_name` | string | No | Exact CI class/table, e.g. `cmdb_ci_server`, `cmdb_ci_db_instance`, `cmdb_ci_appl` |
+| `discovery_source` | string | No | `discovery_source` value, e.g. `ServiceNow`, `SCCM`, `JDBC` |
+| `install_status` | string | No | `install_status` value (numeric value, not label), e.g. `1` (Installed), `7` (Retired) |
+| `last_discovered_after` | string | No | Only CIs last discovered on/after this date. `YYYY-MM-DD` or ISO 8601 (with timezone) |
+| `last_discovered_before` | string | No | Only CIs last discovered on/before this date. `YYYY-MM-DD` or ISO 8601 (with timezone) |
+| `limit` | number | No | 1-100, default 20 |
+| `offset` | number | No | Pagination offset, default 0 |
+
+**Returns**: CI summaries (`sys_id`, `name`, `sys_class_name`, `install_status`, `operational_status`, `discovery_source`, `last_discovered`, `ip_address`, `fqdn`, `serial_number`, `asset_tag`, `owned_by`, `managed_by`, `support_group`, `assignment_group`, `location`, `company`, `sys_updated_on`) with `self_link`, plus pagination `metadata`.
+
+## `get_ci`
+
+Get the full record for one CI by `sys_id`. Fetched from the `cmdb_ci` parent without a `sysparm_fields` restriction so all columns on the CI's concrete subclass are returned.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `sys_id` | string | Yes | Configuration item `sys_id` (32 hex chars) |
+
+**Validation**: invalid `sys_id` returns `VALIDATION_ERROR` without an API call. An unknown but well-formed `sys_id` surfaces the ServiceNow 404 through the standard error envelope.
+
+**Returns**: the full CI record plus `self_link`.
+
+## `get_ci_relationships`
+
+Read `cmdb_rel_ci` for a CI in both directions. `parent_of` holds rows where the CI is the parent (it is the parent **of** each row's child); `child_of` holds rows where the CI is the child (it is a child **of** each row's parent). Critical for judging whether dependency mapping has any data.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `sys_id` | string | Yes | Configuration item `sys_id` (32 hex chars) |
+| `limit` | number | No | Max relationship rows per direction. 1-1000, default 200 |
+
+**Returns**: `ci_sys_id`, `parent_of` and `child_of` arrays (`sys_id`, `parent`, `child`, `type`, `sys_updated_on`, `self_link` per row), and per-direction `metadata` (`total_count`, `returned_count`, `truncated`) so the caller can tell when a direction was capped by `limit`.
+
+## `count_cis_by_class`
+
+Aggregate the entire CMDB by class via the ServiceNow Aggregate API (`/api/now/stats/cmdb_ci` grouped by `sys_class_name` with counts). One call returns the shape of the whole CMDB. Takes no parameters.
+
+**Returns**: `classes` — `{ sys_class_name, label, count }` sorted by `count` descending (classes with an empty name are dropped) — and `metadata` with `class_count` and `total_cis`.
+
+## `find_stale_cis`
+
+Find migration-skip candidates by **one** staleness signal per call (run once per `reason`), ordered by most recently updated.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `reason` | enum | Yes | `not_recently_discovered`, `retired_but_operational`, or `missing_assignment_group` |
+| `stale_after_days` | number | No | For `not_recently_discovered`: flag CIs whose `last_discovered` is older than this many days. 1-3650, default 90 |
+| `sys_class_name` | string | No | Optionally scope to a single CI class/table |
+| `limit` | number | No | 1-100, default 20 |
+| `offset` | number | No | Pagination offset, default 0 |
+
+Reason semantics:
+
+- `not_recently_discovered` → `last_discovered` earlier than `now − stale_after_days` (UTC cutoff).
+- `retired_but_operational` → `install_status=7` (Retired) **and** `operational_status=1` (Operational) — a data-quality contradiction.
+- `missing_assignment_group` → `assignment_group` is empty.
+
+**Returns**: matching CI summaries with `self_link`, plus `metadata` echoing `reason` (and `stale_after_days` for `not_recently_discovered`) alongside pagination fields.
+
+## `get_ci_ticket_references`
+
+Count `incident`, `change_request`, and `problem` records that reference the CI via their `cmdb_ci` field, with a small sample of the most recent of each. Answers "is this CI actually used?".
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `sys_id` | string | Yes | Configuration item `sys_id` (32 hex chars) |
+| `sample_limit` | number | No | Most-recent sample records per ticket type. 0-20, default 5 (`0` = counts only) |
+
+Counts come from the `X-Total-Count` header, so they are accurate regardless of `sample_limit`.
+
+**Returns**: `ci` (identity record plus `self_link`), `references` keyed by `incidents` / `changes` / `problems` (`count`, `returned`, `sample[]` with per-record `self_link`), and `metadata.total_references`.
+
+---
+
+**See also**: [Flow Logs](./flow-logs.md) · [Scheduled Jobs](./scheduled-jobs.md) · [Input Validation](../security/input-validation.md)

--- a/src/tools/cmdb.ts
+++ b/src/tools/cmdb.ts
@@ -1,0 +1,645 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { ToolContext } from "./registry.js";
+import { buildRecordUrl } from "./registry.js";
+import type {
+  ServiceNowListResponse,
+  ServiceNowSingleResponse,
+} from "../servicenow/types.js";
+import { sanitizeValue } from "../servicenow/queryBuilder.js";
+import { validateSysId, normalizeDateBoundary } from "../utils/validators.js";
+
+type WrapHandler = <T>(
+  handler: (ctx: ToolContext, args: T) => Promise<unknown>
+) => (args: T) => Promise<{
+  content: { type: "text"; text: string }[];
+  isError?: boolean;
+}>;
+
+// cmdb_ci is the parent CMDB table; every CI class (cmdb_ci_server,
+// cmdb_ci_db_instance, cmdb_ci_appl, …) extends it, so querying the parent
+// surfaces every configuration item in one call. sys_class_name on each row
+// identifies the concrete subclass. cmdb_rel_ci holds directed parent→child
+// relationships used by dependency mapping.
+const CI_TABLE = "cmdb_ci";
+const REL_TABLE = "cmdb_rel_ci";
+
+// Reference fields are returned as display values because the shared client
+// forces sysparm_display_value=true, so owned_by/location/support_group/etc.
+// come back as readable names (the "dot-walked" owner/location/group view).
+const CI_SUMMARY_FIELDS = [
+  "sys_id",
+  "name",
+  "sys_class_name",
+  "install_status",
+  "operational_status",
+  "discovery_source",
+  "last_discovered",
+  "ip_address",
+  "fqdn",
+  "serial_number",
+  "asset_tag",
+  "owned_by",
+  "managed_by",
+  "support_group",
+  "assignment_group",
+  "location",
+  "company",
+  "sys_updated_on",
+].join(",");
+
+const REL_SUMMARY_FIELDS = [
+  "sys_id",
+  "parent",
+  "child",
+  "type",
+  "sys_updated_on",
+].join(",");
+
+const TICKET_SUMMARY_FIELDS = [
+  "sys_id",
+  "number",
+  "short_description",
+  "state",
+  "priority",
+  "sys_updated_on",
+].join(",");
+
+// Tables whose cmdb_ci reference field tells us a CI is actually in use.
+const REFERENCE_TABLES: Array<["incidents" | "changes" | "problems", string]> =
+  [
+    ["incidents", "incident"],
+    ["changes", "change_request"],
+    ["problems", "problem"],
+  ];
+
+interface CiRecord {
+  sys_id: string;
+  name?: string;
+  sys_class_name?: string;
+  [key: string]: unknown;
+}
+
+interface RelRecord {
+  sys_id: string;
+  [key: string]: unknown;
+}
+
+interface TicketRecord {
+  sys_id: string;
+  [key: string]: unknown;
+}
+
+interface AggregateGroup {
+  stats?: { count?: string };
+  groupby_fields?: { field: string; value: string; display_value?: string }[];
+}
+
+// Link to the concrete subclass table when known (mirrors resolveTable() in
+// scheduledJobs.ts for the sysauto parent/subclass hierarchy). cmdb_ci.do also
+// resolves to the record's real class form, so the parent table is a safe
+// fallback when sys_class_name is absent.
+function resolveTable(record: { sys_class_name?: string }): string {
+  return record.sys_class_name && record.sys_class_name.length > 0
+    ? record.sys_class_name
+    : CI_TABLE;
+}
+
+export function registerCmdbTools(
+  server: McpServer,
+  wrapHandler: WrapHandler
+): void {
+  // search_cis
+  server.tool(
+    "search_cis",
+    "Search the CMDB (cmdb_ci and every subclass: cmdb_ci_server, cmdb_ci_db_instance, cmdb_ci_appl, …) by class, name, discovery source, install status, and last-discovered date range. This is the workhorse for assessing CMDB shape and data quality. Returns a paginated summary list ordered by most recently updated.",
+    {
+      name: z
+        .string()
+        .optional()
+        .describe("Filter by CI name (LIKE match)"),
+      sys_class_name: z
+        .string()
+        .optional()
+        .describe(
+          "Filter by exact CI class/table, e.g. 'cmdb_ci_server', 'cmdb_ci_db_instance', 'cmdb_ci_appl'"
+        ),
+      discovery_source: z
+        .string()
+        .optional()
+        .describe(
+          "Filter by discovery_source, e.g. 'ServiceNow', 'SCCM', 'JDBC'"
+        ),
+      install_status: z
+        .string()
+        .optional()
+        .describe(
+          "Filter by install_status value (numeric value, not label), e.g. '1' (Installed), '7' (Retired)"
+        ),
+      last_discovered_after: z
+        .string()
+        .optional()
+        .describe(
+          "Only CIs last discovered on/after this date. YYYY-MM-DD or ISO 8601 (with timezone)."
+        ),
+      last_discovered_before: z
+        .string()
+        .optional()
+        .describe(
+          "Only CIs last discovered on/before this date. YYYY-MM-DD or ISO 8601 (with timezone)."
+        ),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .default(20)
+        .describe("Maximum results"),
+      offset: z
+        .number()
+        .int()
+        .min(0)
+        .default(0)
+        .describe("Result offset for pagination"),
+    },
+    wrapHandler(
+      async (
+        ctx: ToolContext,
+        args: {
+          name?: string;
+          sys_class_name?: string;
+          discovery_source?: string;
+          install_status?: string;
+          last_discovered_after?: string;
+          last_discovered_before?: string;
+          limit: number;
+          offset: number;
+        }
+      ) => {
+        const queryParts: string[] = [];
+
+        if (args.name) {
+          queryParts.push(`nameLIKE${sanitizeValue(args.name)}`);
+        }
+        if (args.sys_class_name) {
+          queryParts.push(
+            `sys_class_name=${sanitizeValue(args.sys_class_name)}`
+          );
+        }
+        if (args.discovery_source) {
+          queryParts.push(
+            `discovery_source=${sanitizeValue(args.discovery_source)}`
+          );
+        }
+        if (args.install_status) {
+          queryParts.push(
+            `install_status=${sanitizeValue(args.install_status)}`
+          );
+        }
+
+        const dateFilters: Array<
+          [string | undefined, "from" | "to", string]
+        > = [
+          [args.last_discovered_after, "from", ">="],
+          [args.last_discovered_before, "to", "<="],
+        ];
+        for (const [raw, boundary, op] of dateFilters) {
+          if (!raw) continue;
+          const normalized = normalizeDateBoundary(raw, boundary);
+          if (!normalized) {
+            return {
+              success: false,
+              error: {
+                code: "VALIDATION_ERROR",
+                message: `Invalid date for last_discovered_${boundary === "from" ? "after" : "before"}: ${raw}. Use YYYY-MM-DD or ISO 8601.`,
+              },
+            };
+          }
+          queryParts.push(
+            `last_discovered${op}${sanitizeValue(normalized)}`
+          );
+        }
+
+        queryParts.push("ORDERBYDESCsys_updated_on");
+
+        const { data, headers } = await ctx.snClient.get<
+          ServiceNowListResponse<CiRecord>
+        >(`/api/now/table/${CI_TABLE}`, {
+          params: {
+            sysparm_query: queryParts.join("^"),
+            sysparm_limit: args.limit,
+            sysparm_offset: args.offset,
+            sysparm_fields: CI_SUMMARY_FIELDS,
+          },
+        });
+
+        return {
+          success: true,
+          data: data.result.map((r) => ({
+            ...r,
+            self_link: buildRecordUrl(
+              ctx.instanceUrl,
+              resolveTable(r),
+              r.sys_id
+            ),
+          })),
+          metadata: {
+            total_count: parseInt(headers["x-total-count"] || "0", 10),
+            returned_count: data.result.length,
+            offset: args.offset,
+          },
+        };
+      }
+    )
+  );
+
+  // get_ci
+  server.tool(
+    "get_ci",
+    "Get the full record for one configuration item by sys_id. Fetched from the cmdb_ci parent without a field restriction so every column on the CI's concrete subclass is returned; reference fields (owned_by, managed_by, location, support_group, assignment_group) come back as readable display values.",
+    {
+      sys_id: z
+        .string()
+        .describe("Configuration item sys_id (32 hex chars)"),
+    },
+    wrapHandler(async (ctx: ToolContext, args: { sys_id: string }) => {
+      if (!validateSysId(args.sys_id)) {
+        return {
+          success: false,
+          error: {
+            code: "VALIDATION_ERROR",
+            message: "sys_id must be a 32-character sys_id",
+          },
+        };
+      }
+
+      const { data } = await ctx.snClient.get<
+        ServiceNowSingleResponse<CiRecord>
+      >(`/api/now/table/${CI_TABLE}/${args.sys_id}`);
+
+      return {
+        success: true,
+        data: {
+          ...data.result,
+          self_link: buildRecordUrl(
+            ctx.instanceUrl,
+            resolveTable(data.result),
+            data.result.sys_id
+          ),
+        },
+      };
+    })
+  );
+
+  // get_ci_relationships
+  server.tool(
+    "get_ci_relationships",
+    "Read cmdb_rel_ci for a configuration item in both directions: rows where the CI is the parent (parent_of) and rows where it is the child (child_of). Use this to assess dependency-mapping coverage and relationship health for a CI. Returns up to `limit` rows per direction with per-direction truncation flags.",
+    {
+      sys_id: z
+        .string()
+        .describe("Configuration item sys_id (32 hex chars)"),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(1000)
+        .default(200)
+        .describe("Maximum relationship rows per direction"),
+    },
+    wrapHandler(
+      async (
+        ctx: ToolContext,
+        args: { sys_id: string; limit: number }
+      ) => {
+        if (!validateSysId(args.sys_id)) {
+          return {
+            success: false,
+            error: {
+              code: "VALIDATION_ERROR",
+              message: "sys_id must be a 32-character sys_id",
+            },
+          };
+        }
+
+        // parent=<ci> ⇒ the CI is the parent of each row's child;
+        // child=<ci>  ⇒ the CI is the child of each row's parent.
+        const fetchRel = async (field: "parent" | "child") => {
+          const { data, headers } = await ctx.snClient.get<
+            ServiceNowListResponse<RelRecord>
+          >(`/api/now/table/${REL_TABLE}`, {
+            params: {
+              sysparm_query: `${field}=${args.sys_id}^ORDERBYDESCsys_updated_on`,
+              sysparm_limit: args.limit,
+              sysparm_fields: REL_SUMMARY_FIELDS,
+            },
+          });
+          const totalCount = parseInt(
+            headers["x-total-count"] || "0",
+            10
+          );
+          return {
+            rows: data.result.map((r) => ({
+              ...r,
+              self_link: buildRecordUrl(
+                ctx.instanceUrl,
+                REL_TABLE,
+                r.sys_id
+              ),
+            })),
+            metadata: {
+              total_count: totalCount,
+              returned_count: data.result.length,
+              truncated: totalCount > data.result.length,
+            },
+          };
+        };
+
+        const asParent = await fetchRel("parent");
+        const asChild = await fetchRel("child");
+
+        return {
+          success: true,
+          data: {
+            ci_sys_id: args.sys_id,
+            parent_of: asParent.rows,
+            child_of: asChild.rows,
+            metadata: {
+              parent_of: asParent.metadata,
+              child_of: asChild.metadata,
+            },
+          },
+        };
+      }
+    )
+  );
+
+  // count_cis_by_class
+  server.tool(
+    "count_cis_by_class",
+    "Aggregate the entire CMDB by class via the ServiceNow Aggregate API (/api/now/stats/cmdb_ci grouped by sys_class_name with counts). One call returns the shape of the whole CMDB: a count per CI class sorted by count descending, plus the grand total and number of populated classes.",
+    {},
+    wrapHandler(async (ctx: ToolContext) => {
+      const { data } = await ctx.snClient.get<{
+        result: AggregateGroup[] | AggregateGroup;
+      }>(`/api/now/stats/${CI_TABLE}`, {
+        params: {
+          sysparm_group_by: "sys_class_name",
+          sysparm_count: true,
+        },
+      });
+
+      const groups = Array.isArray(data.result)
+        ? data.result
+        : data.result
+          ? [data.result]
+          : [];
+
+      const classes = groups
+        .map((g) => {
+          const gb =
+            g.groupby_fields?.find(
+              (f) => f.field === "sys_class_name"
+            ) ?? g.groupby_fields?.[0];
+          const count = parseInt(g.stats?.count ?? "0", 10);
+          return {
+            sys_class_name: gb?.value ?? "",
+            label: gb?.display_value ?? gb?.value ?? "",
+            count: Number.isFinite(count) ? count : 0,
+          };
+        })
+        .filter((c) => c.sys_class_name.length > 0)
+        .sort((a, b) => b.count - a.count);
+
+      const total = classes.reduce((sum, c) => sum + c.count, 0);
+
+      return {
+        success: true,
+        data: {
+          classes,
+          metadata: {
+            class_count: classes.length,
+            total_cis: total,
+          },
+        },
+      };
+    })
+  );
+
+  // find_stale_cis
+  server.tool(
+    "find_stale_cis",
+    "Find migration-skip candidate CIs by one staleness signal at a time: 'not_recently_discovered' (last_discovered older than stale_after_days), 'retired_but_operational' (install_status Retired yet operational_status Operational), or 'missing_assignment_group' (no assignment_group). Run once per reason. Returns a paginated list with the matching reason echoed in metadata.",
+    {
+      reason: z
+        .enum([
+          "not_recently_discovered",
+          "retired_but_operational",
+          "missing_assignment_group",
+        ])
+        .describe(
+          "Which staleness signal to filter on (run once per reason)"
+        ),
+      stale_after_days: z
+        .number()
+        .int()
+        .min(1)
+        .max(3650)
+        .default(90)
+        .describe(
+          "For reason 'not_recently_discovered': flag CIs whose last_discovered is older than this many days"
+        ),
+      sys_class_name: z
+        .string()
+        .optional()
+        .describe(
+          "Optionally scope to a single CI class/table, e.g. 'cmdb_ci_server'"
+        ),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .default(20)
+        .describe("Maximum results"),
+      offset: z
+        .number()
+        .int()
+        .min(0)
+        .default(0)
+        .describe("Result offset for pagination"),
+    },
+    wrapHandler(
+      async (
+        ctx: ToolContext,
+        args: {
+          reason:
+            | "not_recently_discovered"
+            | "retired_but_operational"
+            | "missing_assignment_group";
+          stale_after_days: number;
+          sys_class_name?: string;
+          limit: number;
+          offset: number;
+        }
+      ) => {
+        const queryParts: string[] = [];
+
+        if (args.sys_class_name) {
+          queryParts.push(
+            `sys_class_name=${sanitizeValue(args.sys_class_name)}`
+          );
+        }
+
+        if (args.reason === "not_recently_discovered") {
+          const cutoffMs =
+            Date.now() - args.stale_after_days * 24 * 60 * 60 * 1000;
+          // Same UTC "YYYY-MM-DD HH:MM:SS" shape ServiceNow encoded queries
+          // compare date/time fields against (see normalizeDateBoundary).
+          const cutoff = new Date(cutoffMs)
+            .toISOString()
+            .slice(0, 19)
+            .replace("T", " ");
+          queryParts.push(`last_discovered<${sanitizeValue(cutoff)}`);
+        } else if (args.reason === "retired_but_operational") {
+          // install_status 7 = Retired; operational_status 1 = Operational.
+          // A retired CI still flagged operational is a data-quality red flag.
+          queryParts.push("install_status=7");
+          queryParts.push("operational_status=1");
+        } else {
+          queryParts.push("assignment_groupISEMPTY");
+        }
+
+        queryParts.push("ORDERBYDESCsys_updated_on");
+
+        const { data, headers } = await ctx.snClient.get<
+          ServiceNowListResponse<CiRecord>
+        >(`/api/now/table/${CI_TABLE}`, {
+          params: {
+            sysparm_query: queryParts.join("^"),
+            sysparm_limit: args.limit,
+            sysparm_offset: args.offset,
+            sysparm_fields: CI_SUMMARY_FIELDS,
+          },
+        });
+
+        return {
+          success: true,
+          data: data.result.map((r) => ({
+            ...r,
+            self_link: buildRecordUrl(
+              ctx.instanceUrl,
+              resolveTable(r),
+              r.sys_id
+            ),
+          })),
+          metadata: {
+            reason: args.reason,
+            ...(args.reason === "not_recently_discovered"
+              ? { stale_after_days: args.stale_after_days }
+              : {}),
+            total_count: parseInt(headers["x-total-count"] || "0", 10),
+            returned_count: data.result.length,
+            offset: args.offset,
+          },
+        };
+      }
+    )
+  );
+
+  // get_ci_ticket_references
+  server.tool(
+    "get_ci_ticket_references",
+    "Count incident, change_request, and problem records that reference a configuration item (via their cmdb_ci field), with a small sample of the most recent of each. Use this to judge which CIs are actually in use versus safe to skip during a migration.",
+    {
+      sys_id: z
+        .string()
+        .describe("Configuration item sys_id (32 hex chars)"),
+      sample_limit: z
+        .number()
+        .int()
+        .min(0)
+        .max(20)
+        .default(5)
+        .describe(
+          "Most-recent sample records to return per ticket type (0 = counts only)"
+        ),
+    },
+    wrapHandler(
+      async (
+        ctx: ToolContext,
+        args: { sys_id: string; sample_limit: number }
+      ) => {
+        if (!validateSysId(args.sys_id)) {
+          return {
+            success: false,
+            error: {
+              code: "VALIDATION_ERROR",
+              message: "sys_id must be a 32-character sys_id",
+            },
+          };
+        }
+
+        // Resolve the CI first so callers get its identity (and a 404 for an
+        // unknown sys_id) before we tally references.
+        const { data: ciData } = await ctx.snClient.get<
+          ServiceNowSingleResponse<CiRecord>
+        >(`/api/now/table/${CI_TABLE}/${args.sys_id}`, {
+          params: { sysparm_fields: "sys_id,name,sys_class_name" },
+        });
+
+        const references: Record<
+          string,
+          { count: number; returned: number; sample: unknown[] }
+        > = {};
+        let totalReferences = 0;
+
+        for (const [key, table] of REFERENCE_TABLES) {
+          const { data, headers } = await ctx.snClient.get<
+            ServiceNowListResponse<TicketRecord>
+          >(`/api/now/table/${table}`, {
+            params: {
+              sysparm_query: `cmdb_ci=${args.sys_id}^ORDERBYDESCsys_updated_on`,
+              sysparm_limit: args.sample_limit,
+              sysparm_fields: TICKET_SUMMARY_FIELDS,
+            },
+          });
+          // X-Total-Count reflects all matching records regardless of the page
+          // size, so sample_limit=0 still yields an accurate count.
+          const count = parseInt(headers["x-total-count"] || "0", 10);
+          totalReferences += count;
+          references[key] = {
+            count,
+            returned: data.result.length,
+            sample: data.result.map((r) => ({
+              ...r,
+              self_link: buildRecordUrl(
+                ctx.instanceUrl,
+                table,
+                r.sys_id
+              ),
+            })),
+          };
+        }
+
+        return {
+          success: true,
+          data: {
+            ci: {
+              ...ciData.result,
+              self_link: buildRecordUrl(
+                ctx.instanceUrl,
+                resolveTable(ciData.result),
+                ciData.result.sys_id
+              ),
+            },
+            references,
+            metadata: {
+              total_references: totalReferences,
+            },
+          },
+        };
+      }
+    )
+  );
+}

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -18,6 +18,7 @@ import { registerChangeRequestTools } from "./changeRequests.js";
 import { registerCatalogAdminTools } from "./catalogAdmin.js";
 import { registerScheduledJobTools } from "./scheduledJobs.js";
 import { registerFlowLogTools } from "./flowLogs.js";
+import { registerCmdbTools } from "./cmdb.js";
 import { registerCatalogPrompts } from "../prompts/catalog.js";
 import { registerIncidentPrompts } from "../prompts/incidents.js";
 import { registerChangeRequestPrompts } from "../prompts/changeRequests.js";
@@ -120,6 +121,7 @@ export function registerAllTools(
   registerCatalogAdminTools(server, wrapHandler);
   registerScheduledJobTools(server, wrapHandler);
   registerFlowLogTools(server, wrapHandler);
+  registerCmdbTools(server, wrapHandler);
 
   registerCatalogPrompts(server);
   registerResources(server, getContext);

--- a/tests/unit/tools/cmdb.test.ts
+++ b/tests/unit/tools/cmdb.test.ts
@@ -1,0 +1,630 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { registerCmdbTools } from "../../../src/tools/cmdb.js";
+import type { ToolContext } from "../../../src/tools/registry.js";
+
+type WrappedHandler<T = unknown> = (args: T) => Promise<unknown>;
+
+describe("registerCmdbTools", () => {
+  const sysId = "0123456789abcdef0123456789abcdef";
+
+  function setup() {
+    const handlers: Record<string, WrappedHandler> = {};
+
+    const server = {
+      tool: vi.fn(
+        (
+          name: string,
+          _description: string,
+          _schema: unknown,
+          handler: WrappedHandler
+        ) => {
+          handlers[name] = handler;
+        }
+      ),
+    };
+
+    const snClient = {
+      get: vi.fn(),
+      patch: vi.fn(),
+      post: vi.fn(),
+    };
+
+    const ctx: ToolContext = {
+      snClient: snClient as unknown as ToolContext["snClient"],
+      instanceUrl: "https://example.service-now.com",
+      userSysId: "abc123def456abc123def456abc12345",
+      userName: "john.doe",
+      displayName: "John Doe",
+    };
+
+    const wrapHandler = <T>(
+      handler: (context: ToolContext, args: T) => Promise<unknown>
+    ) => {
+      return async (args: T) => handler(ctx, args);
+    };
+
+    registerCmdbTools(server as never, wrapHandler);
+
+    return { handlers, snClient, server };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // --- search_cis -----------------------------------------------------------
+
+  it("search_cis builds a query from every filter and links to the subclass", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.get.mockResolvedValue({
+      data: {
+        result: [
+          { sys_id: "ci-1", name: "host01", sys_class_name: "cmdb_ci_server" },
+        ],
+      },
+      headers: { "x-total-count": "1" },
+    });
+
+    const result = (await handlers.search_cis({
+      name: "host",
+      sys_class_name: "cmdb_ci_server",
+      discovery_source: "SCCM",
+      install_status: "1",
+      last_discovered_after: "2026-01-01",
+      last_discovered_before: "2026-03-01",
+      limit: 20,
+      offset: 0,
+    })) as {
+      success: boolean;
+      data: { self_link: string }[];
+      metadata: { total_count: number; returned_count: number; offset: number };
+    };
+
+    expect(snClient.get).toHaveBeenCalledWith(
+      "/api/now/table/cmdb_ci",
+      expect.objectContaining({
+        params: expect.objectContaining({
+          sysparm_query:
+            "nameLIKEhost^sys_class_name=cmdb_ci_server^discovery_source=SCCM^install_status=1^last_discovered>=2026-01-01 00:00:00^last_discovered<=2026-03-01 23:59:59^ORDERBYDESCsys_updated_on",
+          sysparm_limit: 20,
+          sysparm_offset: 0,
+        }),
+      })
+    );
+    expect(result.success).toBe(true);
+    expect(result.data[0].self_link).toBe(
+      "https://example.service-now.com/cmdb_ci_server.do?sys_id=ci-1"
+    );
+    expect(result.metadata).toEqual({
+      total_count: 1,
+      returned_count: 1,
+      offset: 0,
+    });
+  });
+
+  it("search_cis with no filters orders only, and falls back to cmdb_ci for self_link", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.get.mockResolvedValue({
+      data: { result: [{ sys_id: "ci-2", name: "orphan" }] },
+      headers: { "x-total-count": "1" },
+    });
+
+    const result = (await handlers.search_cis({
+      limit: 20,
+      offset: 0,
+    })) as { data: { self_link: string }[] };
+
+    expect(snClient.get).toHaveBeenCalledWith(
+      "/api/now/table/cmdb_ci",
+      expect.objectContaining({
+        params: expect.objectContaining({
+          sysparm_query: "ORDERBYDESCsys_updated_on",
+        }),
+      })
+    );
+    expect(result.data[0].self_link).toBe(
+      "https://example.service-now.com/cmdb_ci.do?sys_id=ci-2"
+    );
+  });
+
+  it("search_cis rejects an invalid last_discovered_after date", async () => {
+    const { handlers, snClient } = setup();
+
+    const result = (await handlers.search_cis({
+      last_discovered_after: "not-a-date",
+      limit: 20,
+      offset: 0,
+    })) as { success: boolean; error: { code: string; message: string } };
+
+    expect(snClient.get).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.error.code).toBe("VALIDATION_ERROR");
+    expect(result.error.message).toContain("last_discovered_after");
+  });
+
+  it("search_cis rejects an invalid last_discovered_before date", async () => {
+    const { handlers, snClient } = setup();
+
+    const result = (await handlers.search_cis({
+      last_discovered_before: "2026-13-99",
+      limit: 20,
+      offset: 0,
+    })) as { success: boolean; error: { code: string; message: string } };
+
+    expect(snClient.get).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.error.code).toBe("VALIDATION_ERROR");
+    expect(result.error.message).toContain("last_discovered_before");
+  });
+
+  // --- get_ci ---------------------------------------------------------------
+
+  it("get_ci fetches the full record and links to its subclass", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.get.mockResolvedValue({
+      data: {
+        result: {
+          sys_id: sysId,
+          name: "db-prod-01",
+          sys_class_name: "cmdb_ci_db_instance",
+        },
+      },
+      headers: {},
+    });
+
+    const result = (await handlers.get_ci({ sys_id: sysId })) as {
+      success: boolean;
+      data: { self_link: string };
+    };
+
+    expect(snClient.get).toHaveBeenCalledWith(
+      `/api/now/table/cmdb_ci/${sysId}`
+    );
+    expect(result.success).toBe(true);
+    expect(result.data.self_link).toBe(
+      `https://example.service-now.com/cmdb_ci_db_instance.do?sys_id=${sysId}`
+    );
+  });
+
+  it("get_ci rejects an invalid sys_id", async () => {
+    const { handlers, snClient } = setup();
+
+    const result = (await handlers.get_ci({ sys_id: "not-a-sys-id" })) as {
+      success: boolean;
+      error: { code: string };
+    };
+
+    expect(snClient.get).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  // --- get_ci_relationships -------------------------------------------------
+
+  it("get_ci_relationships fetches both directions with truncation flags", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.get
+      .mockResolvedValueOnce({
+        data: { result: [{ sys_id: "rel-p1" }] },
+        headers: { "x-total-count": "3" },
+      })
+      .mockResolvedValueOnce({
+        data: { result: [{ sys_id: "rel-c1" }] },
+        headers: { "x-total-count": "1" },
+      });
+
+    const result = (await handlers.get_ci_relationships({
+      sys_id: sysId,
+      limit: 200,
+    })) as {
+      success: boolean;
+      data: {
+        ci_sys_id: string;
+        parent_of: { sys_id: string; self_link: string }[];
+        child_of: { sys_id: string; self_link: string }[];
+        metadata: {
+          parent_of: { total_count: number; truncated: boolean };
+          child_of: { total_count: number; truncated: boolean };
+        };
+      };
+    };
+
+    expect(snClient.get).toHaveBeenNthCalledWith(
+      1,
+      "/api/now/table/cmdb_rel_ci",
+      expect.objectContaining({
+        params: expect.objectContaining({
+          sysparm_query: `parent=${sysId}^ORDERBYDESCsys_updated_on`,
+          sysparm_limit: 200,
+        }),
+      })
+    );
+    expect(snClient.get).toHaveBeenNthCalledWith(
+      2,
+      "/api/now/table/cmdb_rel_ci",
+      expect.objectContaining({
+        params: expect.objectContaining({
+          sysparm_query: `child=${sysId}^ORDERBYDESCsys_updated_on`,
+        }),
+      })
+    );
+    expect(result.data.ci_sys_id).toBe(sysId);
+    expect(result.data.parent_of[0].self_link).toBe(
+      "https://example.service-now.com/cmdb_rel_ci.do?sys_id=rel-p1"
+    );
+    expect(result.data.child_of[0].self_link).toBe(
+      "https://example.service-now.com/cmdb_rel_ci.do?sys_id=rel-c1"
+    );
+    expect(result.data.metadata.parent_of).toEqual({
+      total_count: 3,
+      returned_count: 1,
+      truncated: true,
+    });
+    expect(result.data.metadata.child_of).toEqual({
+      total_count: 1,
+      returned_count: 1,
+      truncated: false,
+    });
+  });
+
+  it("get_ci_relationships rejects an invalid sys_id", async () => {
+    const { handlers, snClient } = setup();
+
+    const result = (await handlers.get_ci_relationships({
+      sys_id: "nope",
+      limit: 200,
+    })) as { success: boolean; error: { code: string } };
+
+    expect(snClient.get).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  // --- count_cis_by_class ---------------------------------------------------
+
+  it("count_cis_by_class parses, filters, sorts and totals the aggregate", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.get.mockResolvedValue({
+      data: {
+        result: [
+          {
+            stats: { count: "5" },
+            groupby_fields: [
+              {
+                field: "sys_class_name",
+                value: "cmdb_ci_server",
+                display_value: "Server",
+              },
+            ],
+          },
+          {
+            stats: { count: "12" },
+            groupby_fields: [
+              {
+                field: "sys_class_name",
+                value: "cmdb_ci_appl",
+                display_value: "Application",
+              },
+            ],
+          },
+          {
+            stats: { count: "9" },
+            groupby_fields: [
+              { field: "sys_class_name", value: "", display_value: "" },
+            ],
+          },
+        ],
+      },
+      headers: {},
+    });
+
+    const result = (await handlers.count_cis_by_class({})) as {
+      success: boolean;
+      data: {
+        classes: { sys_class_name: string; label: string; count: number }[];
+        metadata: { class_count: number; total_cis: number };
+      };
+    };
+
+    expect(snClient.get).toHaveBeenCalledWith(
+      "/api/now/stats/cmdb_ci",
+      expect.objectContaining({
+        params: expect.objectContaining({
+          sysparm_group_by: "sys_class_name",
+          sysparm_count: true,
+        }),
+      })
+    );
+    expect(result.data.classes).toEqual([
+      { sys_class_name: "cmdb_ci_appl", label: "Application", count: 12 },
+      { sys_class_name: "cmdb_ci_server", label: "Server", count: 5 },
+    ]);
+    expect(result.data.metadata).toEqual({ class_count: 2, total_cis: 17 });
+  });
+
+  it("count_cis_by_class tolerates a single-object result and a missing count", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.get.mockResolvedValue({
+      data: {
+        result: {
+          groupby_fields: [
+            { field: "sys_class_name", value: "cmdb_ci" },
+          ],
+        },
+      },
+      headers: {},
+    });
+
+    const result = (await handlers.count_cis_by_class({})) as {
+      data: {
+        classes: { sys_class_name: string; label: string; count: number }[];
+        metadata: { class_count: number; total_cis: number };
+      };
+    };
+
+    expect(result.data.classes).toEqual([
+      { sys_class_name: "cmdb_ci", label: "cmdb_ci", count: 0 },
+    ]);
+    expect(result.data.metadata).toEqual({ class_count: 1, total_cis: 0 });
+  });
+
+  it("count_cis_by_class handles an empty aggregate result", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.get.mockResolvedValue({
+      data: { result: undefined },
+      headers: {},
+    });
+
+    const result = (await handlers.count_cis_by_class({})) as {
+      data: {
+        classes: unknown[];
+        metadata: { class_count: number; total_cis: number };
+      };
+    };
+
+    expect(result.data.classes).toEqual([]);
+    expect(result.data.metadata).toEqual({ class_count: 0, total_cis: 0 });
+  });
+
+  // --- find_stale_cis -------------------------------------------------------
+
+  it("find_stale_cis not_recently_discovered builds a UTC cutoff query", async () => {
+    const { handlers, snClient } = setup();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-19T12:00:00.000Z"));
+
+    snClient.get.mockResolvedValue({
+      data: { result: [{ sys_id: "ci-stale", sys_class_name: "cmdb_ci_server" }] },
+      headers: { "x-total-count": "1" },
+    });
+
+    const result = (await handlers.find_stale_cis({
+      reason: "not_recently_discovered",
+      stale_after_days: 30,
+      sys_class_name: "cmdb_ci_server",
+      limit: 20,
+      offset: 0,
+    })) as {
+      success: boolean;
+      metadata: { reason: string; stale_after_days: number };
+    };
+
+    expect(snClient.get).toHaveBeenCalledWith(
+      "/api/now/table/cmdb_ci",
+      expect.objectContaining({
+        params: expect.objectContaining({
+          sysparm_query:
+            "sys_class_name=cmdb_ci_server^last_discovered<2026-04-19 12:00:00^ORDERBYDESCsys_updated_on",
+        }),
+      })
+    );
+    expect(result.success).toBe(true);
+    expect(result.metadata.reason).toBe("not_recently_discovered");
+    expect(result.metadata.stale_after_days).toBe(30);
+  });
+
+  it("find_stale_cis retired_but_operational queries the contradiction", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.get.mockResolvedValue({
+      data: { result: [] },
+      headers: { "x-total-count": "0" },
+    });
+
+    const result = (await handlers.find_stale_cis({
+      reason: "retired_but_operational",
+      stale_after_days: 90,
+      limit: 20,
+      offset: 0,
+    })) as { metadata: Record<string, unknown> };
+
+    expect(snClient.get).toHaveBeenCalledWith(
+      "/api/now/table/cmdb_ci",
+      expect.objectContaining({
+        params: expect.objectContaining({
+          sysparm_query:
+            "install_status=7^operational_status=1^ORDERBYDESCsys_updated_on",
+        }),
+      })
+    );
+    expect(result.metadata.reason).toBe("retired_but_operational");
+    expect(result.metadata.stale_after_days).toBeUndefined();
+  });
+
+  it("find_stale_cis missing_assignment_group queries an empty group", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.get.mockResolvedValue({
+      data: { result: [] },
+      headers: { "x-total-count": "0" },
+    });
+
+    await handlers.find_stale_cis({
+      reason: "missing_assignment_group",
+      stale_after_days: 90,
+      limit: 20,
+      offset: 0,
+    });
+
+    expect(snClient.get).toHaveBeenCalledWith(
+      "/api/now/table/cmdb_ci",
+      expect.objectContaining({
+        params: expect.objectContaining({
+          sysparm_query:
+            "assignment_groupISEMPTY^ORDERBYDESCsys_updated_on",
+        }),
+      })
+    );
+  });
+
+  // --- get_ci_ticket_references --------------------------------------------
+
+  it("get_ci_ticket_references counts each ticket type and samples them", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.get
+      .mockResolvedValueOnce({
+        data: {
+          result: {
+            sys_id: sysId,
+            name: "host01",
+            sys_class_name: "cmdb_ci_server",
+          },
+        },
+        headers: {},
+      })
+      .mockResolvedValueOnce({
+        data: { result: [{ sys_id: "inc1", number: "INC0001" }] },
+        headers: { "x-total-count": "4" },
+      })
+      .mockResolvedValueOnce({
+        data: { result: [] },
+        headers: { "x-total-count": "0" },
+      })
+      .mockResolvedValueOnce({
+        data: { result: [{ sys_id: "prb1", number: "PRB0001" }] },
+        headers: { "x-total-count": "2" },
+      });
+
+    const result = (await handlers.get_ci_ticket_references({
+      sys_id: sysId,
+      sample_limit: 5,
+    })) as {
+      success: boolean;
+      data: {
+        ci: { self_link: string };
+        references: Record<
+          string,
+          { count: number; returned: number; sample: { self_link: string }[] }
+        >;
+        metadata: { total_references: number };
+      };
+    };
+
+    expect(snClient.get).toHaveBeenNthCalledWith(
+      1,
+      `/api/now/table/cmdb_ci/${sysId}`,
+      expect.objectContaining({
+        params: { sysparm_fields: "sys_id,name,sys_class_name" },
+      })
+    );
+    expect(snClient.get).toHaveBeenNthCalledWith(
+      2,
+      "/api/now/table/incident",
+      expect.objectContaining({
+        params: expect.objectContaining({
+          sysparm_query: `cmdb_ci=${sysId}^ORDERBYDESCsys_updated_on`,
+          sysparm_limit: 5,
+        }),
+      })
+    );
+    expect(result.success).toBe(true);
+    expect(result.data.ci.self_link).toBe(
+      `https://example.service-now.com/cmdb_ci_server.do?sys_id=${sysId}`
+    );
+    expect(result.data.references.incidents.count).toBe(4);
+    expect(result.data.references.incidents.returned).toBe(1);
+    expect(result.data.references.incidents.sample[0].self_link).toBe(
+      "https://example.service-now.com/incident.do?sys_id=inc1"
+    );
+    expect(result.data.references.changes.count).toBe(0);
+    expect(result.data.references.problems.count).toBe(2);
+    expect(result.data.references.problems.sample[0].self_link).toBe(
+      "https://example.service-now.com/problem.do?sys_id=prb1"
+    );
+    expect(result.data.metadata.total_references).toBe(6);
+  });
+
+  it("get_ci_ticket_references with sample_limit 0 still returns counts", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.get
+      .mockResolvedValueOnce({
+        data: { result: { sys_id: sysId, name: "host01" } },
+        headers: {},
+      })
+      .mockResolvedValueOnce({
+        data: { result: [] },
+        headers: { "x-total-count": "7" },
+      })
+      .mockResolvedValueOnce({
+        data: { result: [] },
+        headers: { "x-total-count": "0" },
+      })
+      .mockResolvedValueOnce({
+        data: { result: [] },
+        headers: { "x-total-count": "0" },
+      });
+
+    const result = (await handlers.get_ci_ticket_references({
+      sys_id: sysId,
+      sample_limit: 0,
+    })) as {
+      data: {
+        references: Record<
+          string,
+          { count: number; returned: number; sample: unknown[] }
+        >;
+        metadata: { total_references: number };
+      };
+    };
+
+    expect(snClient.get).toHaveBeenNthCalledWith(
+      2,
+      "/api/now/table/incident",
+      expect.objectContaining({
+        params: expect.objectContaining({ sysparm_limit: 0 }),
+      })
+    );
+    expect(result.data.references.incidents).toEqual({
+      count: 7,
+      returned: 0,
+      sample: [],
+    });
+    expect(result.data.metadata.total_references).toBe(7);
+  });
+
+  it("get_ci_ticket_references rejects an invalid sys_id", async () => {
+    const { handlers, snClient } = setup();
+
+    const result = (await handlers.get_ci_ticket_references({
+      sys_id: "bad",
+      sample_limit: 5,
+    })) as { success: boolean; error: { code: string } };
+
+    expect(snClient.get).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.error.code).toBe("VALIDATION_ERROR");
+  });
+});

--- a/tests/unit/tools/registry.test.ts
+++ b/tests/unit/tools/registry.test.ts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   registerCatalogAdminTools: vi.fn(),
   registerScheduledJobTools: vi.fn(),
   registerFlowLogTools: vi.fn(),
+  registerCmdbTools: vi.fn(),
   registerCatalogPrompts: vi.fn(),
   registerIncidentPrompts: vi.fn(),
   registerChangeRequestPrompts: vi.fn(),
@@ -63,6 +64,10 @@ vi.mock("../../../src/tools/scheduledJobs.js", () => ({
 
 vi.mock("../../../src/tools/flowLogs.js", () => ({
   registerFlowLogTools: mocks.registerFlowLogTools,
+}));
+
+vi.mock("../../../src/tools/cmdb.js", () => ({
+  registerCmdbTools: mocks.registerCmdbTools,
 }));
 
 vi.mock("../../../src/prompts/catalog.js", () => ({
@@ -172,6 +177,7 @@ describe("registerAllTools", () => {
     mocks.registerCatalogAdminTools.mockImplementation(() => {});
     mocks.registerScheduledJobTools.mockImplementation(() => {});
     mocks.registerFlowLogTools.mockImplementation(() => {});
+    mocks.registerCmdbTools.mockImplementation(() => {});
     mocks.registerCatalogPrompts.mockImplementation(() => {});
     mocks.registerIncidentPrompts.mockImplementation(() => {});
     mocks.registerChangeRequestPrompts.mockImplementation(() => {});


### PR DESCRIPTION
## Summary

Adds a new **cmdb** tool domain (`src/tools/cmdb.ts`) with six read-only tools for assessing CMDB shape, data quality, dependency coverage, and real usage — aimed at CMDB health checks and migration triage.

| Tool | Purpose |
|---|---|
| `search_cis` | The workhorse — query `cmdb_ci` and every subclass by class, name, discovery source, install status, and last-discovered date range |
| `get_ci` | Full record for one CI by `sys_id` (all subclass columns; reference fields as display values) |
| `get_ci_relationships` | `cmdb_rel_ci` in both directions (`parent_of` / `child_of`) with per-direction truncation flags |
| `count_cis_by_class` | Whole-CMDB shape in one call via the Aggregate API (`/api/now/stats/cmdb_ci` grouped by `sys_class_name`) |
| `find_stale_cis` | Migration-skip candidates by one staleness signal per call: `not_recently_discovered`, `retired_but_operational`, `missing_assignment_group` |
| `get_ci_ticket_references` | incident/change/problem reference counts (+ samples) to judge which CIs are actually used |

## Conventions followed

- Mirrors the `flowLogs` / `scheduledJobs` patterns: `WrapHandler` envelope, `sanitizeValue`, `validateSysId`, `normalizeDateBoundary`, `resolveTable` subclass `self_link`, `success`/`error` envelope, pagination `metadata`.
- `registerCmdbTools` wired into `src/tools/registry.ts`; matching mock added to `registry.test.ts` (which mocks every tool module).
- Read-only; no identity-enforcement or input-validation paths touched.

## Tests & validation

- 17 new unit tests in `tests/unit/tools/cmdb.test.ts` covering query building, validation rejections, date boundaries, aggregate parsing (incl. single-object / empty), all three stale reasons, ticket-reference counts, and `self_link` / truncation.
- `npm run build` clean, `npm test` 379/379 passing, coverage above thresholds (`cmdb.ts` 100% statements/functions).

## Docs

- New `docs/tools/cmdb.md` (mirrors the flow-logs doc format).
- Tool indexes bumped 40 → 46 (`docs/tools/README.md`, root `README.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)