### PR TITLE
Add platform metadata read tools for config introspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Comprehensive documentation lives in [`docs/`](./docs/README.md):
 - **[Architecture](./docs/architecture/README.md)** — System design, session lifecycle, request flow, Redis schema
 - **[Authentication](./docs/auth/README.md)** — OAuth flow, token storage, refresh
 - **[Security](./docs/security/README.md)** — Identity enforcement, input validation, rate limiting, error handling
-- **[Tools (52)](./docs/tools/README.md)** — All tools: incidents, change requests, knowledge, update sets, scheduled jobs, flow logs, CMDB, platform metadata, and more
+- **[Tools (53)](./docs/tools/README.md)** — All tools: incidents, change requests, knowledge, update sets, scheduled jobs, flow logs, CMDB, platform metadata, and more
 - **[Resources (5)](./docs/resources/README.md)** — MCP resources for direct record access
 - **[Prompts (7)](./docs/prompts/README.md)** — Guided workflows for incidents, change requests, knowledge, and catalog
 - **[HTTP API](./docs/api/README.md)** — Endpoints and client configuration

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Comprehensive documentation lives in [`docs/`](./docs/README.md):
 - **[Architecture](./docs/architecture/README.md)** — System design, session lifecycle, request flow, Redis schema
 - **[Authentication](./docs/auth/README.md)** — OAuth flow, token storage, refresh
 - **[Security](./docs/security/README.md)** — Identity enforcement, input validation, rate limiting, error handling
-- **[Tools (46)](./docs/tools/README.md)** — All tools: incidents, change requests, knowledge, update sets, scheduled jobs, flow logs, CMDB, and more
+- **[Tools (52)](./docs/tools/README.md)** — All tools: incidents, change requests, knowledge, update sets, scheduled jobs, flow logs, CMDB, platform metadata, and more
 - **[Resources (5)](./docs/resources/README.md)** — MCP resources for direct record access
 - **[Prompts (7)](./docs/prompts/README.md)** — Guided workflows for incidents, change requests, knowledge, and catalog
 - **[HTTP API](./docs/api/README.md)** — Endpoints and client configuration

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,18 +42,18 @@ Server-side protections and enforcement.
 - [Rate Limiting](./security/rate-limiting.md) — Token bucket via Redis Lua script
 - [Error Handling](./security/error-handling.md) — ErrorCode enum and error normalization
 
-## Tools (52)
+## Tools (53)
 
 All MCP tools grouped by domain.
 
-- [Master Index](./tools/README.md) — All 52 tools at a glance
+- [Master Index](./tools/README.md) — All 53 tools at a glance
 - [Incidents](./tools/incidents.md) — 5 tools
 - [Change Requests](./tools/change-requests.md) — 6 tools
 - [Users and Groups](./tools/users-and-groups.md) — 3 tools
 - [Knowledge](./tools/knowledge.md) — 2 tools
 - [Tasks and Approvals](./tools/tasks-and-approvals.md) — 3 tools
 - [Catalog](./tools/catalog.md) — 3 tools
-- [Catalog Administration](./tools/catalog-admin.md) — 11 tools
+- [Catalog Administration](./tools/catalog-admin.md) — 12 tools
 - [Update Sets](./tools/update-sets.md) — 3 tools
 - [Scheduled Jobs](./tools/scheduled-jobs.md) — 2 tools
 - [Flow Logs](./tools/flow-logs.md) — 2 tools

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,11 +42,11 @@ Server-side protections and enforcement.
 - [Rate Limiting](./security/rate-limiting.md) — Token bucket via Redis Lua script
 - [Error Handling](./security/error-handling.md) — ErrorCode enum and error normalization
 
-## Tools (35)
+## Tools (52)
 
 All MCP tools grouped by domain.
 
-- [Master Index](./tools/README.md) — All 35 tools at a glance
+- [Master Index](./tools/README.md) — All 52 tools at a glance
 - [Incidents](./tools/incidents.md) — 5 tools
 - [Change Requests](./tools/change-requests.md) — 6 tools
 - [Users and Groups](./tools/users-and-groups.md) — 3 tools
@@ -54,7 +54,11 @@ All MCP tools grouped by domain.
 - [Tasks and Approvals](./tools/tasks-and-approvals.md) — 3 tools
 - [Catalog](./tools/catalog.md) — 3 tools
 - [Catalog Administration](./tools/catalog-admin.md) — 11 tools
-- [Update Sets](./tools/update-sets.md) — 2 tools
+- [Update Sets](./tools/update-sets.md) — 3 tools
+- [Scheduled Jobs](./tools/scheduled-jobs.md) — 2 tools
+- [Flow Logs](./tools/flow-logs.md) — 2 tools
+- [CMDB](./tools/cmdb.md) — 6 tools
+- [Platform Metadata](./tools/platform-metadata.md) — 6 tools
 
 ## Resources (5)
 

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -1,6 +1,6 @@
 [docs](../README.md) / tools
 
-# Tools (46)
+# Tools (52)
 
 All MCP tools provided by the server, grouped by domain.
 
@@ -54,6 +54,12 @@ All MCP tools provided by the server, grouped by domain.
 | 44 | `count_cis_by_class` | [CMDB](./cmdb.md) | Aggregate CI counts per class (whole-CMDB shape) |
 | 45 | `find_stale_cis` | [CMDB](./cmdb.md) | Find migration-skip candidate CIs by staleness signal |
 | 46 | `get_ci_ticket_references` | [CMDB](./cmdb.md) | Count incident/change/problem refs to a CI |
+| 47 | `search_business_rules` | [Platform Metadata](./platform-metadata.md) | Search business rules (sys_script) by table, when, script body |
+| 48 | `get_business_rule` | [Platform Metadata](./platform-metadata.md) | Get a business rule + full script/condition by sys_id |
+| 49 | `get_list_view` | [Platform Metadata](./platform-metadata.md) | Read list view column layouts (sys_ui_list) + columns |
+| 50 | `search_navigator_modules` | [Platform Metadata](./platform-metadata.md) | Search nav modules (sys_app_module) — where list filters live |
+| 51 | `search_flow_definitions` | [Platform Metadata](./platform-metadata.md) | Search Flow Designer flow/subflow definitions |
+| 52 | `get_flow_definition` | [Platform Metadata](./platform-metadata.md) | Get a flow definition + triggers + ordered action steps |
 
 ## Common Patterns
 

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -1,6 +1,6 @@
 [docs](../README.md) / tools
 
-# Tools (52)
+# Tools (53)
 
 All MCP tools provided by the server, grouped by domain.
 
@@ -39,27 +39,28 @@ All MCP tools provided by the server, grouped by domain.
 | 29 | `create_variable_set` | [Catalog Admin](./catalog-admin.md) | Create a reusable variable set |
 | 30 | `attach_variable_set` | [Catalog Admin](./catalog-admin.md) | Attach a variable set to a catalog item |
 | 31 | `create_catalog_client_script` | [Catalog Admin](./catalog-admin.md) | Create a client-side script |
-| 32 | `create_catalog_ui_policy` | [Catalog Admin](./catalog-admin.md) | Create a UI policy |
-| 33 | `create_catalog_ui_policy_action` | [Catalog Admin](./catalog-admin.md) | Create a UI policy action |
-| 34 | `get_current_update_set` | [Update Sets](./update-sets.md) | Get the current update set |
-| 35 | `change_update_set` | [Update Sets](./update-sets.md) | Change the current update set |
-| 36 | `create_update_set` | [Update Sets](./update-sets.md) | Create a new update set |
-| 37 | `search_scheduled_jobs` | [Scheduled Jobs](./scheduled-jobs.md) | Search Scheduled Script Executions |
-| 38 | `get_scheduled_job` | [Scheduled Jobs](./scheduled-jobs.md) | Get a Scheduled Script Execution by sys_id |
-| 39 | `search_flow_executions` | [Flow Logs](./flow-logs.md) | Search Flow Designer execution history |
-| 40 | `get_flow_execution` | [Flow Logs](./flow-logs.md) | Get a flow execution + its step log by sys_id |
-| 41 | `search_cis` | [CMDB](./cmdb.md) | Search CMDB CIs by class, name, source, status, last-discovered |
-| 42 | `get_ci` | [CMDB](./cmdb.md) | Get full CI record by sys_id |
-| 43 | `get_ci_relationships` | [CMDB](./cmdb.md) | Read cmdb_rel_ci for a CI (parent_of / child_of) |
-| 44 | `count_cis_by_class` | [CMDB](./cmdb.md) | Aggregate CI counts per class (whole-CMDB shape) |
-| 45 | `find_stale_cis` | [CMDB](./cmdb.md) | Find migration-skip candidate CIs by staleness signal |
-| 46 | `get_ci_ticket_references` | [CMDB](./cmdb.md) | Count incident/change/problem refs to a CI |
-| 47 | `search_business_rules` | [Platform Metadata](./platform-metadata.md) | Search business rules (sys_script) by table, when, script body |
-| 48 | `get_business_rule` | [Platform Metadata](./platform-metadata.md) | Get a business rule + full script/condition by sys_id |
-| 49 | `get_list_view` | [Platform Metadata](./platform-metadata.md) | Read list view column layouts (sys_ui_list) + columns |
-| 50 | `search_navigator_modules` | [Platform Metadata](./platform-metadata.md) | Search nav modules (sys_app_module) — where list filters live |
-| 51 | `search_flow_definitions` | [Platform Metadata](./platform-metadata.md) | Search Flow Designer flow/subflow definitions |
-| 52 | `get_flow_definition` | [Platform Metadata](./platform-metadata.md) | Get a flow definition + triggers + ordered action steps |
+| 32 | `update_catalog_client_script` | [Catalog Admin](./catalog-admin.md) | Update an existing client-side script |
+| 33 | `create_catalog_ui_policy` | [Catalog Admin](./catalog-admin.md) | Create a UI policy |
+| 34 | `create_catalog_ui_policy_action` | [Catalog Admin](./catalog-admin.md) | Create a UI policy action |
+| 35 | `get_current_update_set` | [Update Sets](./update-sets.md) | Get the current update set |
+| 36 | `change_update_set` | [Update Sets](./update-sets.md) | Change the current update set |
+| 37 | `create_update_set` | [Update Sets](./update-sets.md) | Create a new update set |
+| 38 | `search_scheduled_jobs` | [Scheduled Jobs](./scheduled-jobs.md) | Search Scheduled Script Executions |
+| 39 | `get_scheduled_job` | [Scheduled Jobs](./scheduled-jobs.md) | Get a Scheduled Script Execution by sys_id |
+| 40 | `search_flow_executions` | [Flow Logs](./flow-logs.md) | Search Flow Designer execution history |
+| 41 | `get_flow_execution` | [Flow Logs](./flow-logs.md) | Get a flow execution + its step log by sys_id |
+| 42 | `search_cis` | [CMDB](./cmdb.md) | Search CMDB CIs by class, name, source, status, last-discovered |
+| 43 | `get_ci` | [CMDB](./cmdb.md) | Get full CI record by sys_id |
+| 44 | `get_ci_relationships` | [CMDB](./cmdb.md) | Read cmdb_rel_ci for a CI (parent_of / child_of) |
+| 45 | `count_cis_by_class` | [CMDB](./cmdb.md) | Aggregate CI counts per class (whole-CMDB shape) |
+| 46 | `find_stale_cis` | [CMDB](./cmdb.md) | Find migration-skip candidate CIs by staleness signal |
+| 47 | `get_ci_ticket_references` | [CMDB](./cmdb.md) | Count incident/change/problem refs to a CI |
+| 48 | `search_business_rules` | [Platform Metadata](./platform-metadata.md) | Search business rules (sys_script) by table, when, script body |
+| 49 | `get_business_rule` | [Platform Metadata](./platform-metadata.md) | Get a business rule + full script/condition by sys_id |
+| 50 | `get_list_view` | [Platform Metadata](./platform-metadata.md) | Read list view column layouts (sys_ui_list) + columns |
+| 51 | `search_navigator_modules` | [Platform Metadata](./platform-metadata.md) | Search nav modules (sys_app_module) — where list filters live |
+| 52 | `search_flow_definitions` | [Platform Metadata](./platform-metadata.md) | Search Flow Designer flow/subflow definitions |
+| 53 | `get_flow_definition` | [Platform Metadata](./platform-metadata.md) | Get a flow definition + triggers + ordered action steps |
 
 ## Common Patterns
 

--- a/docs/tools/catalog-admin.md
+++ b/docs/tools/catalog-admin.md
@@ -1,6 +1,6 @@
 [docs](../README.md) / [tools](./README.md) / catalog-admin
 
-# Catalog Administration Tools (11)
+# Catalog Administration Tools (12)
 
 Tools for building and managing service catalog items, variables, choices, scripts, and UI policies.
 

--- a/docs/tools/platform-metadata.md
+++ b/docs/tools/platform-metadata.md
@@ -1,0 +1,105 @@
+[docs](../README.md) / [tools](./README.md) / platform-metadata
+
+# Platform Metadata Tools (6)
+
+Read-only tools for inspecting **platform configuration** — the business rules, list views, navigator modules, and flow definitions that drive record and UI behaviour. These answer questions like "what sets this field?" and "what filters this list?" without UI access.
+
+- `sys_script` — business rules (server-side automation)
+- `sys_ui_list` / `sys_ui_list_element` — list view column layouts and their columns
+- `sys_app_module` — application navigator modules (where a list's row **filter** lives)
+- `sys_hub_flow` plus `sys_hub_trigger_instance` / `sys_hub_action_instance` — Flow Designer flow definitions and their triggers/steps
+
+All access goes through the per-user ServiceNow client, so the caller's ACLs govern whether these configuration tables are readable. `self_link` is built for every returned record.
+
+> **List filters vs. list columns**: `sys_ui_list` only stores which **columns** a list shows. The **row filter** that scopes a named list (e.g. "Major Incidents") is the encoded query in `sys_app_module.filter` — use `search_navigator_modules` for that.
+
+## `search_business_rules`
+
+Search the `sys_script` table. Returns a paginated summary ordered by most recently updated (`ORDERBYDESCsys_updated_on`).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `table` | string | No | Table the rule runs on (the `collection` field), e.g. `incident`, `cmdb_ci_outage` |
+| `name` | string | No | Business rule name LIKE filter |
+| `when` | string | No | Execution phase: `before`, `after`, `async`, or `display` |
+| `active` | boolean | No | Active flag |
+| `script_contains` | string | No | Substring LIKE match against the `script` body (e.g. a field name). Matches the `script` field only — see note below |
+| `limit` | number | No | 1-100, default 20 |
+| `offset` | number | No | Pagination offset, default 0 |
+
+**Returns**: Rule summaries (`sys_id`, `name`, `collection`, `when`, `order`, `active`, `action_insert/update/delete/query`, `advanced`, `sys_updated_on`, `self_link`) plus pagination `metadata`.
+
+> `script_contains` matches the `script` body only. Logic placed in the `condition` or `filter_condition` fields is **not** searched (the encoded-query escaping rules out a safe multi-field OR). If a script match comes up empty, list a table's rules (`table=...`) and read candidates with `get_business_rule`.
+
+## `get_business_rule`
+
+Get one business rule by `sys_id`, fetched without a `sysparm_fields` restriction so the full `script`, `condition`, and `filter_condition` are returned.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `sys_id` | string | Yes | Business rule `sys_id` (32 hex chars) |
+
+**Returns**: The full `sys_script` record plus `self_link`.
+
+## `get_list_view`
+
+Read list view column layouts (`sys_ui_list`) and their ordered columns (`sys_ui_list_element`, joined via `list_id`). Provide a `sys_id` for one layout, or a `table` to return the base layout(s) for that table.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `sys_id` | string | No | A specific `sys_ui_list` `sys_id` (32 hex chars). Takes precedence over `table` |
+| `table` | string | No | Return layouts defined for this table (the `name` field), e.g. `incident` |
+| `include_personal` | boolean | No | When querying by `table`, also include per-user personal layouts (`sys_user` set). Default `false` returns only shared/base layouts (`sys_userISEMPTY`) |
+| `include_columns` | boolean | No | Fetch the ordered column list per layout (default `true`) |
+| `column_limit` | number | No | Max columns per layout. 1-500, default 200 |
+| `limit` | number | No | Max layouts when querying by `table`. 1-100, default 20 |
+
+**Returns**: An array of layouts, each with the `sys_ui_list` fields, `self_link`, and (when `include_columns`) a `columns` array (`sys_id`, `element`, `position`, `self_link`) in display order plus `column_metadata` (`total_count`, `returned_count`, `truncated`). Provide either `sys_id` or `table` — omitting both is a validation error.
+
+## `search_navigator_modules`
+
+Search application navigator modules (`sys_app_module`) — the left-nav menu items. For a "List of Records" module the `filter` field holds the encoded query that scopes the list, the target table is in `name`, and the label is in `title`. Returns a paginated summary ordered by `title`.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `title` | string | No | Module display label LIKE filter, e.g. `Major Incident` |
+| `table` | string | No | Target table (the `name` field on `sys_app_module`), e.g. `incident` |
+| `active` | boolean | No | Active flag |
+| `limit` | number | No | 1-100, default 20 |
+| `offset` | number | No | Pagination offset, default 0 |
+
+**Returns**: Module summaries (`sys_id`, `title`, `name`, `filter`, `query`, `view`, `application`, `link_type`, `active`, `order`, `roles`, `sys_updated_on`, `self_link`) plus pagination `metadata`.
+
+## `search_flow_definitions`
+
+Search Flow Designer flow/subflow definitions (`sys_hub_flow`) by name, active flag, and type. This is the flow **design**; for execution history use [`search_flow_executions`](./flow-logs.md). Returns a paginated summary ordered by most recently updated.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | No | Flow/subflow name LIKE filter, e.g. `Outage created from MIM` |
+| `active` | boolean | No | Active flag |
+| `type` | string | No | `flow` or `subflow` |
+| `limit` | number | No | 1-100, default 20 |
+| `offset` | number | No | Pagination offset, default 0 |
+
+**Returns**: Flow summaries (`sys_id`, `name`, `description`, `active`, `type`, `run_as`, `status`, `sys_scope`, `sys_updated_on`, `self_link`) plus pagination `metadata`.
+
+## `get_flow_definition`
+
+Get a flow definition (`sys_hub_flow`) by `sys_id`, with its trigger instance(s) and ordered action steps. The header is fetched without a `sysparm_fields` restriction; trigger and action instances are returned with all columns so their table/condition (triggers) and action type/label/order (actions) surface.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `sys_id` | string | Yes | Flow definition `sys_id` (`sys_hub_flow`, 32 hex chars) |
+| `include_components` | boolean | No | Include trigger instances and ordered action steps (default `true`; set `false` for the header only) |
+| `component_limit` | number | No | Max trigger/action rows per type. 1-500, default 200 |
+
+**Returns**: The full flow header plus `self_link`. When `include_components` is true: a `triggers` array, an `actions` array (each row with `self_link`), and `component_metadata` reporting, per type, the source `table`, `total_count`, `returned_count`, and `truncated`.
+
+> **What is and isn't returned**: the trigger's table/condition and the ordered list of steps (with their action type and label) are returned. The per-step input **values** — the literal field assignments, e.g. setting a field to `true` — are stored separately in `sys_variable_value` (keyed by `document` / `document_key`) and are **not** expanded here; open the flow in Flow Designer or inspect those records for literal field writes.
+>
+> **Flow Engine V2**: components are read from the base `sys_hub_trigger_instance` / `sys_hub_action_instance` tables, falling back to the `*_v2` tables (Washington DC and later). `component_metadata[type].table` reports which table the rows came from. If both are empty for a flow you expect to have steps, check the caller's read access to those tables.
+
+---
+
+**See also**: [Flow Logs](./flow-logs.md) · [Scheduled Jobs](./scheduled-jobs.md) · [Input Validation](../security/input-validation.md)

--- a/src/tools/platformMetadata.ts
+++ b/src/tools/platformMetadata.ts
@@ -107,6 +107,20 @@ interface FlowComponentResult {
   truncated: boolean;
 }
 
+// The *_v2 instance tables are absent before Washington DC. The only request
+// made against them here is a well-formed query (a validated sys_id, no field
+// restriction) — and the Table API ignores unknown query/order fields rather
+// than erroring — so the single client-side reason this call can fail is that
+// the table itself is not present, which ServiceNow reports as a 400/404.
+// Operational failures (auth 401, ACL 403, rate-limit 429, and server/transient
+// errors or network timeouts, which the client maps to 500) carry other
+// statuses and must NOT be masked as "no components", so only a 400/404 is
+// treated as a missing table; everything else is rethrown.
+function isMissingTableError(err: unknown): boolean {
+  const status = (err as { statusCode?: number })?.statusCode;
+  return status === 400 || status === 404;
+}
+
 // Fetch a flow's trigger/action instances. Both instance types reference the
 // flow through a `flow` field. The base table is queried first; if it has no
 // rows (a Flow Engine V2 flow keeps its instances in the *_v2 table) the v2
@@ -147,8 +161,9 @@ async function fetchFlowComponents(
   }
 
   // No rows on the base table — try the Flow Engine V2 table. It does not exist
-  // on releases before Washington DC, so swallow a lookup failure and fall back
-  // to the (empty) base result.
+  // on releases before Washington DC; tolerate only that (a 400/404 missing
+  // table) and fall back to the empty base result, but let any real error
+  // (ACL, rate limit, server/transient) propagate through normal handling.
   try {
     const v2 = await ctx.snClient.get<ServiceNowListResponse<SysIdRecord>>(
       `/api/now/table/${v2Table}`,
@@ -157,7 +172,10 @@ async function fetchFlowComponents(
     if (v2.data.result.length > 0) {
       return pack(v2Table, v2.data, v2.headers);
     }
-  } catch {
+  } catch (err) {
+    if (!isMissingTableError(err)) {
+      throw err;
+    }
     // v2 table not present on this release; keep the empty base result below.
   }
 

--- a/src/tools/platformMetadata.ts
+++ b/src/tools/platformMetadata.ts
@@ -1,0 +1,725 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { ToolContext } from "./registry.js";
+import { buildRecordUrl } from "./registry.js";
+import type {
+  ServiceNowListResponse,
+  ServiceNowSingleResponse,
+} from "../servicenow/types.js";
+import { sanitizeValue } from "../servicenow/queryBuilder.js";
+import { validateSysId } from "../utils/validators.js";
+
+type WrapHandler = <T>(
+  handler: (ctx: ToolContext, args: T) => Promise<unknown>
+) => (args: T) => Promise<{
+  content: { type: "text"; text: string }[];
+  isError?: boolean;
+}>;
+
+// Business rules live on sys_script. `collection` is the table the rule runs on,
+// `when` is the execution phase (before/after/async/display), and the logic is in
+// the script / condition / filter_condition fields. The boolean action_* flags
+// say which DB operations the rule fires on.
+const BUSINESS_RULE_TABLE = "sys_script";
+const BUSINESS_RULE_SUMMARY_FIELDS = [
+  "sys_id",
+  "name",
+  "collection",
+  "when",
+  "order",
+  "active",
+  "action_insert",
+  "action_update",
+  "action_delete",
+  "action_query",
+  "advanced",
+  "sys_updated_on",
+].join(",");
+
+// A list view's column layout (sys_ui_list) and its ordered columns
+// (sys_ui_list_element, joined via list_id). The row *filter* for a list is NOT
+// stored here — it lives on the navigator module (sys_app_module.filter); see
+// search_navigator_modules.
+const LIST_TABLE = "sys_ui_list";
+const LIST_ELEMENT_TABLE = "sys_ui_list_element";
+const LIST_SUMMARY_FIELDS = [
+  "sys_id",
+  "name",
+  "view",
+  "sys_user",
+  "parent",
+  "relationship",
+  "label",
+  "sys_updated_on",
+].join(",");
+const LIST_ELEMENT_FIELDS = ["sys_id", "element", "position"].join(",");
+
+// Application navigator modules. For a "List of Records" module the target table
+// is stored in `name` (a ServiceNow quirk — `title` is the human label) and the
+// row filter is the encoded query in `filter`.
+const MODULE_TABLE = "sys_app_module";
+const MODULE_SUMMARY_FIELDS = [
+  "sys_id",
+  "title",
+  "name",
+  "filter",
+  "query",
+  "view",
+  "application",
+  "link_type",
+  "active",
+  "order",
+  "roles",
+  "sys_updated_on",
+].join(",");
+
+// Flow Designer flow definitions (the header record). Trigger and action
+// *instances* link back to the flow via their `flow` reference. Flow Engine V2
+// (Washington DC and later) stores those instances in *_v2 tables; earlier
+// releases use the base tables, so get_flow_definition tries base then v2.
+const FLOW_TABLE = "sys_hub_flow";
+const FLOW_SUMMARY_FIELDS = [
+  "sys_id",
+  "name",
+  "description",
+  "active",
+  "type",
+  "run_as",
+  "status",
+  "sys_scope",
+  "sys_updated_on",
+].join(",");
+const TRIGGER_TABLE = "sys_hub_trigger_instance";
+const TRIGGER_TABLE_V2 = "sys_hub_trigger_instance_v2";
+const ACTION_TABLE = "sys_hub_action_instance";
+const ACTION_TABLE_V2 = "sys_hub_action_instance_v2";
+
+interface SysIdRecord {
+  sys_id: string;
+  [key: string]: unknown;
+}
+
+interface FlowComponentResult {
+  table: string;
+  rows: Array<SysIdRecord & { self_link: string }>;
+  total_count: number;
+  returned_count: number;
+  truncated: boolean;
+}
+
+// Fetch a flow's trigger/action instances. Both instance types reference the
+// flow through a `flow` field. The base table is queried first; if it has no
+// rows (a Flow Engine V2 flow keeps its instances in the *_v2 table) the v2
+// table is tried, tolerating its absence on pre-Washington releases.
+async function fetchFlowComponents(
+  ctx: ToolContext,
+  baseTable: string,
+  v2Table: string,
+  flowSysId: string,
+  limit: number
+): Promise<FlowComponentResult> {
+  const query = `flow=${flowSysId}^ORDERBYorder`;
+
+  const pack = (
+    table: string,
+    data: ServiceNowListResponse<SysIdRecord>,
+    headers: Record<string, string>
+  ): FlowComponentResult => {
+    const totalCount = parseInt(headers["x-total-count"] || "0", 10);
+    return {
+      table,
+      rows: data.result.map((r) => ({
+        ...r,
+        self_link: buildRecordUrl(ctx.instanceUrl, table, r.sys_id),
+      })),
+      total_count: totalCount,
+      returned_count: data.result.length,
+      truncated: totalCount > data.result.length,
+    };
+  };
+
+  const base = await ctx.snClient.get<ServiceNowListResponse<SysIdRecord>>(
+    `/api/now/table/${baseTable}`,
+    { params: { sysparm_query: query, sysparm_limit: limit } }
+  );
+  if (base.data.result.length > 0) {
+    return pack(baseTable, base.data, base.headers);
+  }
+
+  // No rows on the base table — try the Flow Engine V2 table. It does not exist
+  // on releases before Washington DC, so swallow a lookup failure and fall back
+  // to the (empty) base result.
+  try {
+    const v2 = await ctx.snClient.get<ServiceNowListResponse<SysIdRecord>>(
+      `/api/now/table/${v2Table}`,
+      { params: { sysparm_query: query, sysparm_limit: limit } }
+    );
+    if (v2.data.result.length > 0) {
+      return pack(v2Table, v2.data, v2.headers);
+    }
+  } catch {
+    // v2 table not present on this release; keep the empty base result below.
+  }
+
+  return pack(baseTable, base.data, base.headers);
+}
+
+export function registerPlatformMetadataTools(
+  server: McpServer,
+  wrapHandler: WrapHandler
+): void {
+  // search_business_rules
+  server.tool(
+    "search_business_rules",
+    "Search business rules (sys_script) by the table they run on (collection), name, execution phase (when), active flag, and an optional script-body substring. Use this to find server-side automation that writes a field — e.g. a rule on 'incident' or 'cmdb_ci_outage' that sets a custom field. Note: script_contains matches the `script` body only; logic placed in the condition or filter_condition fields is returned by get_business_rule, so list a table's rules and drill in if a script match comes up empty. Returns a paginated summary ordered by most recently updated.",
+    {
+      table: z
+        .string()
+        .optional()
+        .describe(
+          "Filter by the table the rule runs on (the `collection` field), e.g. 'incident', 'cmdb_ci_outage'"
+        ),
+      name: z
+        .string()
+        .optional()
+        .describe("Filter by business rule name (LIKE match)"),
+      when: z
+        .string()
+        .optional()
+        .describe(
+          "Filter by execution phase: 'before', 'after', 'async', or 'display'"
+        ),
+      active: z.boolean().optional().describe("Filter by active flag"),
+      script_contains: z
+        .string()
+        .optional()
+        .describe(
+          "Filter to rules whose `script` body CONTAINS this substring (e.g. a field name like 'u_major_incident'). Matches the script field only."
+        ),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .default(20)
+        .describe("Maximum results"),
+      offset: z
+        .number()
+        .int()
+        .min(0)
+        .default(0)
+        .describe("Result offset for pagination"),
+    },
+    wrapHandler(
+      async (
+        ctx: ToolContext,
+        args: {
+          table?: string;
+          name?: string;
+          when?: string;
+          active?: boolean;
+          script_contains?: string;
+          limit: number;
+          offset: number;
+        }
+      ) => {
+        const queryParts: string[] = [];
+
+        if (args.table) {
+          queryParts.push(`collection=${sanitizeValue(args.table)}`);
+        }
+        if (args.name) {
+          queryParts.push(`nameLIKE${sanitizeValue(args.name)}`);
+        }
+        if (args.when) {
+          queryParts.push(`when=${sanitizeValue(args.when)}`);
+        }
+        if (typeof args.active === "boolean") {
+          queryParts.push(`active=${args.active ? "true" : "false"}`);
+        }
+        if (args.script_contains) {
+          queryParts.push(`scriptLIKE${sanitizeValue(args.script_contains)}`);
+        }
+
+        queryParts.push("ORDERBYDESCsys_updated_on");
+
+        const { data, headers } = await ctx.snClient.get<
+          ServiceNowListResponse<SysIdRecord>
+        >(`/api/now/table/${BUSINESS_RULE_TABLE}`, {
+          params: {
+            sysparm_query: queryParts.join("^"),
+            sysparm_limit: args.limit,
+            sysparm_offset: args.offset,
+            sysparm_fields: BUSINESS_RULE_SUMMARY_FIELDS,
+          },
+        });
+
+        return {
+          success: true,
+          data: data.result.map((r) => ({
+            ...r,
+            self_link: buildRecordUrl(
+              ctx.instanceUrl,
+              BUSINESS_RULE_TABLE,
+              r.sys_id
+            ),
+          })),
+          metadata: {
+            total_count: parseInt(headers["x-total-count"] || "0", 10),
+            returned_count: data.result.length,
+            offset: args.offset,
+          },
+        };
+      }
+    )
+  );
+
+  // get_business_rule
+  server.tool(
+    "get_business_rule",
+    "Get the full record for one business rule (sys_script) by sys_id, including the complete `script` body and the `condition` and `filter_condition` fields. Use this after search_business_rules to read exactly what a rule does.",
+    {
+      sys_id: z.string().describe("Business rule sys_id (32 hex chars)"),
+    },
+    wrapHandler(async (ctx: ToolContext, args: { sys_id: string }) => {
+      if (!validateSysId(args.sys_id)) {
+        return {
+          success: false,
+          error: {
+            code: "VALIDATION_ERROR",
+            message: "sys_id must be a 32-character sys_id",
+          },
+        };
+      }
+
+      const { data } = await ctx.snClient.get<
+        ServiceNowSingleResponse<SysIdRecord>
+      >(`/api/now/table/${BUSINESS_RULE_TABLE}/${args.sys_id}`);
+
+      return {
+        success: true,
+        data: {
+          ...data.result,
+          self_link: buildRecordUrl(
+            ctx.instanceUrl,
+            BUSINESS_RULE_TABLE,
+            data.result.sys_id
+          ),
+        },
+      };
+    })
+  );
+
+  // get_list_view
+  server.tool(
+    "get_list_view",
+    "Read list view column layouts (sys_ui_list) and their ordered columns (sys_ui_list_element). Provide a `sys_id` for one specific layout, or a `table` to return the base list view(s) for that table (e.g. 'incident'). IMPORTANT: this returns which COLUMNS a list shows, not the row filter — a list's filter lives on the navigator module (sys_app_module.filter), so use search_navigator_modules for questions like 'what filters the Major Incidents list'. Returns each matching layout with its columns in display order.",
+    {
+      sys_id: z
+        .string()
+        .optional()
+        .describe(
+          "A specific sys_ui_list sys_id (32 hex chars). Takes precedence over `table`."
+        ),
+      table: z
+        .string()
+        .optional()
+        .describe(
+          "Return list view layouts defined for this table (the sys_ui_list `name` field), e.g. 'incident'"
+        ),
+      include_personal: z
+        .boolean()
+        .default(false)
+        .describe(
+          "When querying by `table`, also include per-user personal list layouts (sys_user set). Default false returns only the shared/base layouts."
+        ),
+      include_columns: z
+        .boolean()
+        .default(true)
+        .describe(
+          "Fetch the ordered column list (sys_ui_list_element) for each layout"
+        ),
+      column_limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(500)
+        .default(200)
+        .describe("Maximum columns to return per layout"),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .default(20)
+        .describe("Maximum layouts to return when querying by `table`"),
+    },
+    wrapHandler(
+      async (
+        ctx: ToolContext,
+        args: {
+          sys_id?: string;
+          table?: string;
+          include_personal: boolean;
+          include_columns: boolean;
+          column_limit: number;
+          limit: number;
+        }
+      ) => {
+        if (!args.sys_id && !args.table) {
+          return {
+            success: false,
+            error: {
+              code: "VALIDATION_ERROR",
+              message: "Provide either sys_id or table",
+            },
+          };
+        }
+
+        let lists: SysIdRecord[];
+        let totalCount: number;
+
+        if (args.sys_id) {
+          if (!validateSysId(args.sys_id)) {
+            return {
+              success: false,
+              error: {
+                code: "VALIDATION_ERROR",
+                message: "sys_id must be a 32-character sys_id",
+              },
+            };
+          }
+          const { data } = await ctx.snClient.get<
+            ServiceNowSingleResponse<SysIdRecord>
+          >(`/api/now/table/${LIST_TABLE}/${args.sys_id}`);
+          lists = [data.result];
+          totalCount = 1;
+        } else {
+          const queryParts = [`name=${sanitizeValue(args.table as string)}`];
+          if (!args.include_personal) {
+            queryParts.push("sys_userISEMPTY");
+          }
+          queryParts.push("ORDERBYview");
+
+          const { data, headers } = await ctx.snClient.get<
+            ServiceNowListResponse<SysIdRecord>
+          >(`/api/now/table/${LIST_TABLE}`, {
+            params: {
+              sysparm_query: queryParts.join("^"),
+              sysparm_limit: args.limit,
+              sysparm_fields: LIST_SUMMARY_FIELDS,
+            },
+          });
+          lists = data.result;
+          totalCount = parseInt(headers["x-total-count"] || "0", 10);
+        }
+
+        const enriched = [];
+        for (const list of lists) {
+          const entry: Record<string, unknown> = {
+            ...list,
+            self_link: buildRecordUrl(ctx.instanceUrl, LIST_TABLE, list.sys_id),
+          };
+
+          if (args.include_columns) {
+            const { data: elementData, headers: elementHeaders } =
+              await ctx.snClient.get<ServiceNowListResponse<SysIdRecord>>(
+                `/api/now/table/${LIST_ELEMENT_TABLE}`,
+                {
+                  params: {
+                    sysparm_query: `list_id=${list.sys_id}^ORDERBYposition`,
+                    sysparm_limit: args.column_limit,
+                    sysparm_fields: LIST_ELEMENT_FIELDS,
+                  },
+                }
+              );
+            const elementTotal = parseInt(
+              elementHeaders["x-total-count"] || "0",
+              10
+            );
+            entry.columns = elementData.result.map((e) => ({
+              ...e,
+              self_link: buildRecordUrl(
+                ctx.instanceUrl,
+                LIST_ELEMENT_TABLE,
+                e.sys_id
+              ),
+            }));
+            entry.column_metadata = {
+              total_count: elementTotal,
+              returned_count: elementData.result.length,
+              truncated: elementTotal > elementData.result.length,
+            };
+          }
+
+          enriched.push(entry);
+        }
+
+        return {
+          success: true,
+          data: enriched,
+          metadata: {
+            total_count: totalCount,
+            returned_count: enriched.length,
+          },
+        };
+      }
+    )
+  );
+
+  // search_navigator_modules
+  server.tool(
+    "search_navigator_modules",
+    "Search application navigator modules (sys_app_module) — the menu items in the left-hand nav. For a 'List of Records' module the `filter` field holds the encoded query that scopes the list (this is where a 'Major Incidents' list filter actually lives), the target table is in `name`, and the human label is in `title`. Use this to discover what filters a named list. Returns a paginated summary including filter and query.",
+    {
+      title: z
+        .string()
+        .optional()
+        .describe("Filter by the module's display label (LIKE match), e.g. 'Major Incident'"),
+      table: z
+        .string()
+        .optional()
+        .describe(
+          "Filter by the module's target table (the `name` field on sys_app_module), e.g. 'incident'"
+        ),
+      active: z.boolean().optional().describe("Filter by active flag"),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .default(20)
+        .describe("Maximum results"),
+      offset: z
+        .number()
+        .int()
+        .min(0)
+        .default(0)
+        .describe("Result offset for pagination"),
+    },
+    wrapHandler(
+      async (
+        ctx: ToolContext,
+        args: {
+          title?: string;
+          table?: string;
+          active?: boolean;
+          limit: number;
+          offset: number;
+        }
+      ) => {
+        const queryParts: string[] = [];
+
+        if (args.title) {
+          queryParts.push(`titleLIKE${sanitizeValue(args.title)}`);
+        }
+        if (args.table) {
+          queryParts.push(`name=${sanitizeValue(args.table)}`);
+        }
+        if (typeof args.active === "boolean") {
+          queryParts.push(`active=${args.active ? "true" : "false"}`);
+        }
+
+        queryParts.push("ORDERBYtitle");
+
+        const { data, headers } = await ctx.snClient.get<
+          ServiceNowListResponse<SysIdRecord>
+        >(`/api/now/table/${MODULE_TABLE}`, {
+          params: {
+            sysparm_query: queryParts.join("^"),
+            sysparm_limit: args.limit,
+            sysparm_offset: args.offset,
+            sysparm_fields: MODULE_SUMMARY_FIELDS,
+          },
+        });
+
+        return {
+          success: true,
+          data: data.result.map((r) => ({
+            ...r,
+            self_link: buildRecordUrl(ctx.instanceUrl, MODULE_TABLE, r.sys_id),
+          })),
+          metadata: {
+            total_count: parseInt(headers["x-total-count"] || "0", 10),
+            returned_count: data.result.length,
+            offset: args.offset,
+          },
+        };
+      }
+    )
+  );
+
+  // search_flow_definitions
+  server.tool(
+    "search_flow_definitions",
+    "Search Flow Designer flow/subflow definitions (sys_hub_flow) by name, active flag, and type. Use this to find a flow by name (e.g. 'Outage created from MIM'), then read what it does with get_flow_definition. This is the flow *design*; for execution history use search_flow_executions instead. Returns a paginated summary ordered by most recently updated.",
+    {
+      name: z
+        .string()
+        .optional()
+        .describe("Filter by flow/subflow name (LIKE match)"),
+      active: z.boolean().optional().describe("Filter by active flag"),
+      type: z
+        .string()
+        .optional()
+        .describe("Filter by type, e.g. 'flow' or 'subflow'"),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .default(20)
+        .describe("Maximum results"),
+      offset: z
+        .number()
+        .int()
+        .min(0)
+        .default(0)
+        .describe("Result offset for pagination"),
+    },
+    wrapHandler(
+      async (
+        ctx: ToolContext,
+        args: {
+          name?: string;
+          active?: boolean;
+          type?: string;
+          limit: number;
+          offset: number;
+        }
+      ) => {
+        const queryParts: string[] = [];
+
+        if (args.name) {
+          queryParts.push(`nameLIKE${sanitizeValue(args.name)}`);
+        }
+        if (typeof args.active === "boolean") {
+          queryParts.push(`active=${args.active ? "true" : "false"}`);
+        }
+        if (args.type) {
+          queryParts.push(`type=${sanitizeValue(args.type)}`);
+        }
+
+        queryParts.push("ORDERBYDESCsys_updated_on");
+
+        const { data, headers } = await ctx.snClient.get<
+          ServiceNowListResponse<SysIdRecord>
+        >(`/api/now/table/${FLOW_TABLE}`, {
+          params: {
+            sysparm_query: queryParts.join("^"),
+            sysparm_limit: args.limit,
+            sysparm_offset: args.offset,
+            sysparm_fields: FLOW_SUMMARY_FIELDS,
+          },
+        });
+
+        return {
+          success: true,
+          data: data.result.map((r) => ({
+            ...r,
+            self_link: buildRecordUrl(ctx.instanceUrl, FLOW_TABLE, r.sys_id),
+          })),
+          metadata: {
+            total_count: parseInt(headers["x-total-count"] || "0", 10),
+            returned_count: data.result.length,
+            offset: args.offset,
+          },
+        };
+      }
+    )
+  );
+
+  // get_flow_definition
+  server.tool(
+    "get_flow_definition",
+    "Get a Flow Designer flow definition (sys_hub_flow) by sys_id, with its trigger instance(s) and ordered action steps. The flow header gives name/active/type/scope; the triggers reveal what fires the flow (e.g. their table and condition columns); the action instances list the ordered steps with their action type and label. NOTE: the per-step input VALUES (the actual field assignments, e.g. setting a field to true) are stored separately (sys_variable_value) and are NOT expanded here — open the flow in Flow Designer or inspect those records to see literal field writes. Components are read from the base instance tables, falling back to the Flow Engine V2 (*_v2) tables on Washington DC and later releases.",
+    {
+      sys_id: z.string().describe("Flow definition sys_id (sys_hub_flow, 32 hex chars)"),
+      include_components: z
+        .boolean()
+        .default(true)
+        .describe(
+          "Include the flow's trigger instances and ordered action steps (set false for the header only)"
+        ),
+      component_limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(500)
+        .default(200)
+        .describe("Maximum trigger/action instance rows to return per type"),
+    },
+    wrapHandler(
+      async (
+        ctx: ToolContext,
+        args: {
+          sys_id: string;
+          include_components: boolean;
+          component_limit: number;
+        }
+      ) => {
+        if (!validateSysId(args.sys_id)) {
+          return {
+            success: false,
+            error: {
+              code: "VALIDATION_ERROR",
+              message: "sys_id must be a 32-character sys_id",
+            },
+          };
+        }
+
+        const { data } = await ctx.snClient.get<
+          ServiceNowSingleResponse<SysIdRecord>
+        >(`/api/now/table/${FLOW_TABLE}/${args.sys_id}`);
+
+        const result: Record<string, unknown> = {
+          ...data.result,
+          self_link: buildRecordUrl(
+            ctx.instanceUrl,
+            FLOW_TABLE,
+            data.result.sys_id
+          ),
+        };
+
+        if (args.include_components) {
+          const triggers = await fetchFlowComponents(
+            ctx,
+            TRIGGER_TABLE,
+            TRIGGER_TABLE_V2,
+            args.sys_id,
+            args.component_limit
+          );
+          const actions = await fetchFlowComponents(
+            ctx,
+            ACTION_TABLE,
+            ACTION_TABLE_V2,
+            args.sys_id,
+            args.component_limit
+          );
+
+          result.triggers = triggers.rows;
+          result.actions = actions.rows;
+          result.component_metadata = {
+            triggers: {
+              table: triggers.table,
+              total_count: triggers.total_count,
+              returned_count: triggers.returned_count,
+              truncated: triggers.truncated,
+            },
+            actions: {
+              table: actions.table,
+              total_count: actions.total_count,
+              returned_count: actions.returned_count,
+              truncated: actions.truncated,
+            },
+          };
+        }
+
+        return {
+          success: true,
+          data: result,
+        };
+      }
+    )
+  );
+}

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -19,6 +19,7 @@ import { registerCatalogAdminTools } from "./catalogAdmin.js";
 import { registerScheduledJobTools } from "./scheduledJobs.js";
 import { registerFlowLogTools } from "./flowLogs.js";
 import { registerCmdbTools } from "./cmdb.js";
+import { registerPlatformMetadataTools } from "./platformMetadata.js";
 import { registerCatalogPrompts } from "../prompts/catalog.js";
 import { registerIncidentPrompts } from "../prompts/incidents.js";
 import { registerChangeRequestPrompts } from "../prompts/changeRequests.js";
@@ -122,6 +123,7 @@ export function registerAllTools(
   registerScheduledJobTools(server, wrapHandler);
   registerFlowLogTools(server, wrapHandler);
   registerCmdbTools(server, wrapHandler);
+  registerPlatformMetadataTools(server, wrapHandler);
 
   registerCatalogPrompts(server);
   registerResources(server, getContext);

--- a/tests/unit/tools/platformMetadata.test.ts
+++ b/tests/unit/tools/platformMetadata.test.ts
@@ -602,6 +602,32 @@ describe("registerPlatformMetadataTools", () => {
     });
   });
 
+  it("get_flow_definition rethrows a non-missing-table error (e.g. 403) from the *_v2 lookup", async () => {
+    const { handlers, snClient } = setup();
+    const sysId = "0123456789abcdef0123456789abcdef";
+
+    snClient.get
+      .mockResolvedValueOnce({
+        data: { result: { sys_id: sysId, name: "Outage created from MIM" } },
+        headers: {},
+      })
+      // base trigger empty, then the v2 trigger lookup fails with a 403 (ACL)
+      .mockResolvedValueOnce({ data: { result: [] }, headers: { "x-total-count": "0" } })
+      .mockRejectedValueOnce({ statusCode: 403, message: "Insufficient permissions" });
+
+    // The ACL error must surface, not be masked as "no components".
+    await expect(
+      handlers.get_flow_definition({
+        sys_id: sysId,
+        include_components: true,
+        component_limit: 200,
+      })
+    ).rejects.toMatchObject({ statusCode: 403 });
+
+    // header + base trigger + v2 trigger (which threw) — short-circuits there
+    expect(snClient.get).toHaveBeenCalledTimes(3);
+  });
+
   it("get_flow_definition with include_components=false fetches only the header", async () => {
     const { handlers, snClient } = setup();
     const sysId = "0123456789abcdef0123456789abcdef";

--- a/tests/unit/tools/platformMetadata.test.ts
+++ b/tests/unit/tools/platformMetadata.test.ts
@@ -1,0 +1,626 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerPlatformMetadataTools } from "../../../src/tools/platformMetadata.js";
+import type { ToolContext } from "../../../src/tools/registry.js";
+
+type WrappedHandler<T = unknown> = (args: T) => Promise<unknown>;
+
+describe("registerPlatformMetadataTools", () => {
+  const userSysId = "abc123def456abc123def456abc12345";
+
+  function setup() {
+    const handlers: Record<string, WrappedHandler> = {};
+
+    const server = {
+      tool: vi.fn(
+        (
+          name: string,
+          _description: string,
+          _schema: unknown,
+          handler: WrappedHandler
+        ) => {
+          handlers[name] = handler;
+        }
+      ),
+    };
+
+    const snClient = {
+      get: vi.fn(),
+      patch: vi.fn(),
+      post: vi.fn(),
+    };
+
+    const ctx: ToolContext = {
+      snClient: snClient as unknown as ToolContext["snClient"],
+      instanceUrl: "https://example.service-now.com",
+      userSysId,
+      userName: "john.doe",
+      displayName: "John Doe",
+    };
+
+    const wrapHandler = <T>(
+      handler: (context: ToolContext, args: T) => Promise<unknown>
+    ) => {
+      return async (args: T) => handler(ctx, args);
+    };
+
+    registerPlatformMetadataTools(server as never, wrapHandler);
+
+    return { handlers, snClient, server };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ---- search_business_rules ------------------------------------------------
+
+  it("search_business_rules builds query from table, name, when, active, and script_contains", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.get.mockResolvedValue({
+      data: { result: [{ sys_id: "br-001", name: "Set major incident" }] },
+      headers: { "x-total-count": "1" },
+    });
+
+    const result = (await handlers.search_business_rules({
+      table: "incident",
+      name: "major",
+      when: "after",
+      active: true,
+      script_contains: "u_major_incident",
+      limit: 20,
+      offset: 0,
+    })) as {
+      success: boolean;
+      data: { sys_id: string; self_link: string }[];
+      metadata: { total_count: number; returned_count: number; offset: number };
+    };
+
+    expect(snClient.get).toHaveBeenCalledWith(
+      "/api/now/table/sys_script",
+      expect.objectContaining({
+        params: expect.objectContaining({
+          sysparm_query:
+            "collection=incident^nameLIKEmajor^when=after^active=true^scriptLIKEu_major_incident^ORDERBYDESCsys_updated_on",
+          sysparm_limit: 20,
+          sysparm_offset: 0,
+        }),
+      })
+    );
+    expect(result.success).toBe(true);
+    expect(result.data[0].self_link).toBe(
+      "https://example.service-now.com/sys_script.do?sys_id=br-001"
+    );
+    expect(result.metadata).toEqual({
+      total_count: 1,
+      returned_count: 1,
+      offset: 0,
+    });
+  });
+
+  it("search_business_rules encodes active=false", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.get.mockResolvedValue({
+      data: { result: [] },
+      headers: { "x-total-count": "0" },
+    });
+
+    await handlers.search_business_rules({ active: false, limit: 20, offset: 0 });
+
+    expect(snClient.get).toHaveBeenCalledWith(
+      "/api/now/table/sys_script",
+      expect.objectContaining({
+        params: expect.objectContaining({
+          sysparm_query: "active=false^ORDERBYDESCsys_updated_on",
+        }),
+      })
+    );
+  });
+
+  // ---- get_business_rule ----------------------------------------------------
+
+  it("get_business_rule returns the full record with a self_link", async () => {
+    const { handlers, snClient } = setup();
+    const sysId = "0123456789abcdef0123456789abcdef";
+
+    snClient.get.mockResolvedValue({
+      data: {
+        result: {
+          sys_id: sysId,
+          name: "Set major incident",
+          script: "current.u_major_incident = true;",
+        },
+      },
+      headers: {},
+    });
+
+    const result = (await handlers.get_business_rule({ sys_id: sysId })) as {
+      success: boolean;
+      data: { sys_id: string; self_link: string; script: string };
+    };
+
+    expect(snClient.get).toHaveBeenCalledWith(
+      `/api/now/table/sys_script/${sysId}`
+    );
+    expect(result.success).toBe(true);
+    expect(result.data.script).toBe("current.u_major_incident = true;");
+    expect(result.data.self_link).toBe(
+      `https://example.service-now.com/sys_script.do?sys_id=${sysId}`
+    );
+  });
+
+  it("get_business_rule rejects an invalid sys_id", async () => {
+    const { handlers, snClient } = setup();
+
+    const result = (await handlers.get_business_rule({
+      sys_id: "not-a-sys-id",
+    })) as { success: boolean; error: { code: string } };
+
+    expect(snClient.get).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  // ---- get_list_view --------------------------------------------------------
+
+  it("get_list_view requires either sys_id or table", async () => {
+    const { handlers, snClient } = setup();
+
+    const result = (await handlers.get_list_view({
+      include_personal: false,
+      include_columns: true,
+      column_limit: 200,
+      limit: 20,
+    })) as { success: boolean; error: { code: string } };
+
+    expect(snClient.get).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("get_list_view by table excludes personal lists and fetches ordered columns", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.get
+      .mockResolvedValueOnce({
+        data: { result: [{ sys_id: "list-001", name: "incident" }] },
+        headers: { "x-total-count": "1" },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          result: [
+            { sys_id: "el-001", element: "number", position: "0" },
+            { sys_id: "el-002", element: "short_description", position: "1" },
+          ],
+        },
+        headers: { "x-total-count": "2" },
+      });
+
+    const result = (await handlers.get_list_view({
+      table: "incident",
+      include_personal: false,
+      include_columns: true,
+      column_limit: 200,
+      limit: 20,
+    })) as {
+      success: boolean;
+      data: {
+        sys_id: string;
+        self_link: string;
+        columns: { element: string; self_link: string }[];
+        column_metadata: { total_count: number; truncated: boolean };
+      }[];
+      metadata: { total_count: number; returned_count: number };
+    };
+
+    expect(snClient.get).toHaveBeenNthCalledWith(
+      1,
+      "/api/now/table/sys_ui_list",
+      expect.objectContaining({
+        params: expect.objectContaining({
+          sysparm_query: "name=incident^sys_userISEMPTY^ORDERBYview",
+        }),
+      })
+    );
+    expect(snClient.get).toHaveBeenNthCalledWith(
+      2,
+      "/api/now/table/sys_ui_list_element",
+      expect.objectContaining({
+        params: expect.objectContaining({
+          sysparm_query: "list_id=list-001^ORDERBYposition",
+        }),
+      })
+    );
+    expect(result.success).toBe(true);
+    expect(result.data[0].self_link).toBe(
+      "https://example.service-now.com/sys_ui_list.do?sys_id=list-001"
+    );
+    expect(result.data[0].columns).toHaveLength(2);
+    expect(result.data[0].columns[0].self_link).toBe(
+      "https://example.service-now.com/sys_ui_list_element.do?sys_id=el-001"
+    );
+    expect(result.data[0].column_metadata).toEqual({
+      total_count: 2,
+      returned_count: 2,
+      truncated: false,
+    });
+    expect(result.metadata).toEqual({ total_count: 1, returned_count: 1 });
+  });
+
+  it("get_list_view with include_personal omits the sys_userISEMPTY filter", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.get.mockResolvedValue({
+      data: { result: [] },
+      headers: { "x-total-count": "0" },
+    });
+
+    await handlers.get_list_view({
+      table: "incident",
+      include_personal: true,
+      include_columns: false,
+      column_limit: 200,
+      limit: 20,
+    });
+
+    expect(snClient.get).toHaveBeenCalledTimes(1);
+    expect(snClient.get).toHaveBeenCalledWith(
+      "/api/now/table/sys_ui_list",
+      expect.objectContaining({
+        params: expect.objectContaining({
+          sysparm_query: "name=incident^ORDERBYview",
+        }),
+      })
+    );
+  });
+
+  it("get_list_view by sys_id fetches the single layout and its columns", async () => {
+    const { handlers, snClient } = setup();
+    const sysId = "0123456789abcdef0123456789abcdef";
+
+    snClient.get
+      .mockResolvedValueOnce({
+        data: { result: { sys_id: sysId, name: "incident" } },
+        headers: {},
+      })
+      .mockResolvedValueOnce({
+        data: { result: [{ sys_id: "el-001", element: "number", position: "0" }] },
+        headers: { "x-total-count": "1" },
+      });
+
+    const result = (await handlers.get_list_view({
+      sys_id: sysId,
+      include_personal: false,
+      include_columns: true,
+      column_limit: 200,
+      limit: 20,
+    })) as {
+      success: boolean;
+      data: { sys_id: string; columns: unknown[] }[];
+      metadata: { total_count: number };
+    };
+
+    expect(snClient.get).toHaveBeenNthCalledWith(
+      1,
+      `/api/now/table/sys_ui_list/${sysId}`
+    );
+    expect(result.success).toBe(true);
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].columns).toHaveLength(1);
+    expect(result.metadata.total_count).toBe(1);
+  });
+
+  it("get_list_view rejects an invalid sys_id", async () => {
+    const { handlers, snClient } = setup();
+
+    const result = (await handlers.get_list_view({
+      sys_id: "not-a-sys-id",
+      include_personal: false,
+      include_columns: true,
+      column_limit: 200,
+      limit: 20,
+    })) as { success: boolean; error: { code: string } };
+
+    expect(snClient.get).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  // ---- search_navigator_modules ---------------------------------------------
+
+  it("search_navigator_modules builds query from title, table, and active and surfaces the filter", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.get.mockResolvedValue({
+      data: {
+        result: [
+          {
+            sys_id: "mod-001",
+            title: "Major Incidents",
+            name: "incident",
+            filter: "u_major_incident=true",
+          },
+        ],
+      },
+      headers: { "x-total-count": "1" },
+    });
+
+    const result = (await handlers.search_navigator_modules({
+      title: "Major Incident",
+      table: "incident",
+      active: true,
+      limit: 20,
+      offset: 0,
+    })) as {
+      success: boolean;
+      data: { sys_id: string; filter: string; self_link: string }[];
+    };
+
+    expect(snClient.get).toHaveBeenCalledWith(
+      "/api/now/table/sys_app_module",
+      expect.objectContaining({
+        params: expect.objectContaining({
+          sysparm_query:
+            "titleLIKEMajor Incident^name=incident^active=true^ORDERBYtitle",
+        }),
+      })
+    );
+    expect(result.success).toBe(true);
+    expect(result.data[0].filter).toBe("u_major_incident=true");
+    expect(result.data[0].self_link).toBe(
+      "https://example.service-now.com/sys_app_module.do?sys_id=mod-001"
+    );
+  });
+
+  // ---- search_flow_definitions ----------------------------------------------
+
+  it("search_flow_definitions builds query from name, active, and type", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.get.mockResolvedValue({
+      data: { result: [{ sys_id: "flow-001", name: "Outage created from MIM" }] },
+      headers: { "x-total-count": "1" },
+    });
+
+    const result = (await handlers.search_flow_definitions({
+      name: "Outage created from MIM",
+      active: true,
+      type: "flow",
+      limit: 20,
+      offset: 0,
+    })) as { success: boolean; data: { self_link: string }[] };
+
+    expect(snClient.get).toHaveBeenCalledWith(
+      "/api/now/table/sys_hub_flow",
+      expect.objectContaining({
+        params: expect.objectContaining({
+          sysparm_query:
+            "nameLIKEOutage created from MIM^active=true^type=flow^ORDERBYDESCsys_updated_on",
+        }),
+      })
+    );
+    expect(result.success).toBe(true);
+    expect(result.data[0].self_link).toBe(
+      "https://example.service-now.com/sys_hub_flow.do?sys_id=flow-001"
+    );
+  });
+
+  // ---- get_flow_definition --------------------------------------------------
+
+  it("get_flow_definition rejects an invalid sys_id", async () => {
+    const { handlers, snClient } = setup();
+
+    const result = (await handlers.get_flow_definition({
+      sys_id: "not-a-sys-id",
+      include_components: true,
+      component_limit: 200,
+    })) as { success: boolean; error: { code: string } };
+
+    expect(snClient.get).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("get_flow_definition returns header, triggers, and actions from the base tables", async () => {
+    const { handlers, snClient } = setup();
+    const sysId = "0123456789abcdef0123456789abcdef";
+
+    snClient.get
+      .mockResolvedValueOnce({
+        data: { result: { sys_id: sysId, name: "Outage created from MIM" } },
+        headers: {},
+      })
+      .mockResolvedValueOnce({
+        data: { result: [{ sys_id: "trg-001", order: "0" }] },
+        headers: { "x-total-count": "1" },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          result: [
+            { sys_id: "act-001", order: "1" },
+            { sys_id: "act-002", order: "2" },
+          ],
+        },
+        headers: { "x-total-count": "2" },
+      });
+
+    const result = (await handlers.get_flow_definition({
+      sys_id: sysId,
+      include_components: true,
+      component_limit: 200,
+    })) as {
+      success: boolean;
+      data: {
+        self_link: string;
+        triggers: { sys_id: string; self_link: string }[];
+        actions: { sys_id: string; self_link: string }[];
+        component_metadata: {
+          triggers: { table: string; total_count: number };
+          actions: { table: string; total_count: number; truncated: boolean };
+        };
+      };
+    };
+
+    // header, then base trigger table, then base action table — no v2 calls
+    expect(snClient.get).toHaveBeenCalledTimes(3);
+    expect(snClient.get).toHaveBeenNthCalledWith(
+      2,
+      "/api/now/table/sys_hub_trigger_instance",
+      expect.objectContaining({
+        params: expect.objectContaining({
+          sysparm_query: `flow=${sysId}^ORDERBYorder`,
+        }),
+      })
+    );
+    expect(snClient.get).toHaveBeenNthCalledWith(
+      3,
+      "/api/now/table/sys_hub_action_instance",
+      expect.objectContaining({
+        params: expect.objectContaining({
+          sysparm_query: `flow=${sysId}^ORDERBYorder`,
+        }),
+      })
+    );
+    expect(result.success).toBe(true);
+    expect(result.data.self_link).toBe(
+      `https://example.service-now.com/sys_hub_flow.do?sys_id=${sysId}`
+    );
+    expect(result.data.triggers[0].self_link).toBe(
+      "https://example.service-now.com/sys_hub_trigger_instance.do?sys_id=trg-001"
+    );
+    expect(result.data.actions).toHaveLength(2);
+    expect(result.data.component_metadata.triggers.table).toBe(
+      "sys_hub_trigger_instance"
+    );
+    expect(result.data.component_metadata.actions).toEqual({
+      table: "sys_hub_action_instance",
+      total_count: 2,
+      returned_count: 2,
+      truncated: false,
+    });
+  });
+
+  it("get_flow_definition falls back to the *_v2 tables when the base tables are empty", async () => {
+    const { handlers, snClient } = setup();
+    const sysId = "0123456789abcdef0123456789abcdef";
+
+    snClient.get
+      // header
+      .mockResolvedValueOnce({
+        data: { result: { sys_id: sysId, name: "Outage created from MIM" } },
+        headers: {},
+      })
+      // base trigger table — empty
+      .mockResolvedValueOnce({
+        data: { result: [] },
+        headers: { "x-total-count": "0" },
+      })
+      // v2 trigger table — has rows
+      .mockResolvedValueOnce({
+        data: { result: [{ sys_id: "trg-v2-001", order: "0" }] },
+        headers: { "x-total-count": "1" },
+      })
+      // base action table — empty
+      .mockResolvedValueOnce({
+        data: { result: [] },
+        headers: { "x-total-count": "0" },
+      })
+      // v2 action table — has rows
+      .mockResolvedValueOnce({
+        data: { result: [{ sys_id: "act-v2-001", order: "1" }] },
+        headers: { "x-total-count": "1" },
+      });
+
+    const result = (await handlers.get_flow_definition({
+      sys_id: sysId,
+      include_components: true,
+      component_limit: 200,
+    })) as {
+      success: boolean;
+      data: {
+        triggers: { self_link: string }[];
+        component_metadata: { triggers: { table: string }; actions: { table: string } };
+      };
+    };
+
+    expect(snClient.get).toHaveBeenCalledTimes(5);
+    expect(snClient.get).toHaveBeenNthCalledWith(
+      3,
+      "/api/now/table/sys_hub_trigger_instance_v2",
+      expect.anything()
+    );
+    expect(result.data.component_metadata.triggers.table).toBe(
+      "sys_hub_trigger_instance_v2"
+    );
+    expect(result.data.component_metadata.actions.table).toBe(
+      "sys_hub_action_instance_v2"
+    );
+    expect(result.data.triggers[0].self_link).toBe(
+      "https://example.service-now.com/sys_hub_trigger_instance_v2.do?sys_id=trg-v2-001"
+    );
+  });
+
+  it("get_flow_definition tolerates a missing *_v2 table and returns empty components", async () => {
+    const { handlers, snClient } = setup();
+    const sysId = "0123456789abcdef0123456789abcdef";
+
+    snClient.get
+      .mockResolvedValueOnce({
+        data: { result: { sys_id: sysId, name: "Outage created from MIM" } },
+        headers: {},
+      })
+      // base trigger empty, then v2 trigger lookup throws (table absent)
+      .mockResolvedValueOnce({ data: { result: [] }, headers: { "x-total-count": "0" } })
+      .mockRejectedValueOnce({ statusCode: 400, message: "invalid table" })
+      // base action empty, then v2 action lookup throws
+      .mockResolvedValueOnce({ data: { result: [] }, headers: { "x-total-count": "0" } })
+      .mockRejectedValueOnce({ statusCode: 400, message: "invalid table" });
+
+    const result = (await handlers.get_flow_definition({
+      sys_id: sysId,
+      include_components: true,
+      component_limit: 200,
+    })) as {
+      success: boolean;
+      data: {
+        triggers: unknown[];
+        actions: unknown[];
+        component_metadata: { triggers: { table: string; total_count: number } };
+      };
+    };
+
+    expect(result.success).toBe(true);
+    expect(result.data.triggers).toEqual([]);
+    expect(result.data.actions).toEqual([]);
+    // falls back to the (empty) base result rather than throwing
+    expect(result.data.component_metadata.triggers).toEqual({
+      table: "sys_hub_trigger_instance",
+      total_count: 0,
+      returned_count: 0,
+      truncated: false,
+    });
+  });
+
+  it("get_flow_definition with include_components=false fetches only the header", async () => {
+    const { handlers, snClient } = setup();
+    const sysId = "0123456789abcdef0123456789abcdef";
+
+    snClient.get.mockResolvedValue({
+      data: { result: { sys_id: sysId, name: "Outage created from MIM" } },
+      headers: {},
+    });
+
+    const result = (await handlers.get_flow_definition({
+      sys_id: sysId,
+      include_components: false,
+      component_limit: 200,
+    })) as { success: boolean; data: Record<string, unknown> };
+
+    expect(snClient.get).toHaveBeenCalledTimes(1);
+    expect(result.success).toBe(true);
+    expect(result.data.triggers).toBeUndefined();
+    expect(result.data.actions).toBeUndefined();
+    expect(result.data.component_metadata).toBeUndefined();
+  });
+});

--- a/tests/unit/tools/registry.test.ts
+++ b/tests/unit/tools/registry.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   registerScheduledJobTools: vi.fn(),
   registerFlowLogTools: vi.fn(),
   registerCmdbTools: vi.fn(),
+  registerPlatformMetadataTools: vi.fn(),
   registerCatalogPrompts: vi.fn(),
   registerIncidentPrompts: vi.fn(),
   registerChangeRequestPrompts: vi.fn(),
@@ -68,6 +69,10 @@ vi.mock("../../../src/tools/flowLogs.js", () => ({
 
 vi.mock("../../../src/tools/cmdb.js", () => ({
   registerCmdbTools: mocks.registerCmdbTools,
+}));
+
+vi.mock("../../../src/tools/platformMetadata.js", () => ({
+  registerPlatformMetadataTools: mocks.registerPlatformMetadataTools,
 }));
 
 vi.mock("../../../src/prompts/catalog.js", () => ({
@@ -178,6 +183,7 @@ describe("registerAllTools", () => {
     mocks.registerScheduledJobTools.mockImplementation(() => {});
     mocks.registerFlowLogTools.mockImplementation(() => {});
     mocks.registerCmdbTools.mockImplementation(() => {});
+    mocks.registerPlatformMetadataTools.mockImplementation(() => {});
     mocks.registerCatalogPrompts.mockImplementation(() => {});
     mocks.registerIncidentPrompts.mockImplementation(() => {});
     mocks.registerChangeRequestPrompts.mockImplementation(() => {});


### PR DESCRIPTION
## Summary

Adds a **Platform Metadata** read-tool domain — six read-only MCP tools for inspecting the platform configuration that drives record and UI behavior, so agents can answer "what sets this field?" and "what filters this list?" without UI access.

| Tool | Table(s) | Purpose |
|---|---|---|
| `search_business_rules` | `sys_script` | Find business rules by table (`collection`), `when`, active, script-body substring |
| `get_business_rule` | `sys_script` | Full record incl. `script` / `condition` / `filter_condition` |
| `get_list_view` | `sys_ui_list` (+ `sys_ui_list_element`) | List column layout by `sys_id` or `table` |
| `search_navigator_modules` | `sys_app_module` | Nav modules + their encoded `filter` (where a list's row-filter actually lives) |
| `search_flow_definitions` | `sys_hub_flow` | Find a flow/subflow by name |
| `get_flow_definition` | `sys_hub_flow` + trigger/action instances | Flow header + triggers + ordered steps, with Flow Engine V2 `*_v2` fallback |

## Design notes
- **Per-step field-writes are not decoded.** A flow's literal field assignments live in `sys_variable_value` (document/document_key) — version-fragile — so `get_flow_definition` returns the trigger (table/condition) and ordered steps and points to the flow/those records for literal writes.
- **`script_contains` matches the `script` body only** (encoded-query escaping rules out a safe cross-field OR); `condition`/`filter_condition` are returned by `get_business_rule`.
- **Flow Engine V2:** components are read from the base instance tables, falling back to the `*_v2` tables (Washington DC+); `component_metadata[type].table` reports the source table.
- Read-only and per-user: all access goes through the authenticated ServiceNow client, so the caller's ACLs govern visibility of these config tables.

## Validation
- `npm run build` clean
- 16 new unit tests; full suite **395 passing across 35 files**
- `npm run test:coverage` thresholds held (`platformMetadata.ts` 100% lines)

## Docs
- New `docs/tools/platform-metadata.md`
- Tool counts synced in `docs/tools/README.md`, `docs/README.md`, root `README.md` (→ 52); also corrected pre-existing drift in `docs/README.md` (was missing Scheduled Jobs / Flow Logs / CMDB and undercounted Update Sets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)