### PR TITLE
fix: stop pagination when total count is reached

### DIFF
--- a/src/servicenow/paginator.ts
+++ b/src/servicenow/paginator.ts
@@ -28,7 +28,7 @@ export async function paginateAll<T>(
     const response = await fetcher(limit, offset);
     totalCount = response.totalCount;
     allResults.push(...response.results);
-    if (response.results.length < limit) {
+    if (startOffset + allResults.length >= totalCount || response.results.length < limit) {
       return { results: allResults, totalCount, truncated: false };
     }
   }

--- a/tests/unit/servicenow/paginator.test.ts
+++ b/tests/unit/servicenow/paginator.test.ts
@@ -45,6 +45,31 @@ describe("paginateAll", () => {
     expect(fetcher).toHaveBeenCalledTimes(2);
   });
 
+  it("stops when fetched results reach totalCount exactly", async () => {
+    const fetcher = vi.fn();
+
+    fetcher.mockResolvedValueOnce({
+      results: [{ id: 1 }, { id: 2 }],
+      totalCount: 4,
+    });
+    fetcher.mockResolvedValueOnce({
+      results: [{ id: 3 }, { id: 4 }],
+      totalCount: 4,
+    });
+
+    const { results, totalCount, truncated } = await paginateAll(fetcher, {
+      limit: 2,
+      maxPages: 5,
+    });
+
+    expect(results).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }]);
+    expect(totalCount).toBe(4);
+    expect(truncated).toBe(false);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(fetcher).toHaveBeenNthCalledWith(1, 2, 0);
+    expect(fetcher).toHaveBeenNthCalledWith(2, 2, 2);
+  });
+
   it("stops when results.length < limit", async () => {
     const fetcher = vi.fn();
 


### PR DESCRIPTION
## Summary
Fixes unnecessary extra pagination requests when the fetched result count exactly reaches the ServiceNow API `totalCount`.

## Root Cause
`paginateAll` only stopped when a page returned fewer results than the page limit. When the total record count was an exact multiple of `limit`, every real page was full, so the paginator requested one additional empty page before stopping.

## Fix
Stop pagination as soon as `startOffset + allResults.length >= totalCount`, while preserving the existing `results.length < limit` fallback.

## Impact
Avoids unnecessary ServiceNow API calls, reducing latency and preventing wasted rate limit usage for exact-multiple result sets.

## Tests
- `npm test -- --run tests/unit/servicenow/paginator.test.ts`
- `npm run build`

Fixes #66