### PR TITLE
Mark logical tool failures as MCP errors

### DIFF
--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -44,6 +44,15 @@ export function buildRecordUrl(
   return `${instanceUrl}/${table}.do?sys_id=${sysId}`;
 }
 
+function isLogicalToolFailure(result: unknown): boolean {
+  return (
+    typeof result === "object" &&
+    result !== null &&
+    "success" in result &&
+    result.success === false
+  );
+}
+
 export function registerAllTools(
   server: McpServer,
   config: Config,
@@ -102,7 +111,10 @@ export function registerAllTools(
           { userName: ctx.userName, duration },
           "Tool call completed"
         );
-        return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+          ...(isLogicalToolFailure(result) ? { isError: true } : {}),
+        };
       } catch (err: unknown) {
         const toolErr = (err as { toolError?: unknown })?.toolError;
         if (toolErr) {

--- a/tests/unit/tools/registry.test.ts
+++ b/tests/unit/tools/registry.test.ts
@@ -270,6 +270,39 @@ describe("registerAllTools", () => {
     expect(parsed.success).toBe(true);
   });
 
+  it("marks logical tool failures as MCP errors", async () => {
+    registerAllTools(
+      {} as any,
+      config as any,
+      {} as any,
+      tokenStore as any
+    );
+
+    const logicalFailure = {
+      success: false,
+      error: {
+        code: "NOT_FOUND",
+        message: "Record was not found",
+      },
+    };
+    const wrapped = capturedWrap(async () => logicalFailure);
+
+    const extra = {
+      authInfo: {
+        token: "mcp-token-123",
+        clientId: "client-1",
+        scopes: [] as string[],
+        extra: { userSysId: "abc123def456abc123def456abc12345" },
+      },
+    };
+
+    const response = await wrapped({} as Record<string, never>, extra);
+
+    expect(response.isError).toBe(true);
+    expect(JSON.parse(response.content[0].text)).toEqual(logicalFailure);
+    expect(mocks.handleToolError).not.toHaveBeenCalled();
+  });
+
   it("passes through known toolError payloads from handlers", async () => {
     registerAllTools(
       {} as any,


### PR DESCRIPTION
Fixes #61.

`wrapHandler` already turns thrown tool errors into MCP `isError: true` responses, but a number of tools return logical failures as normal payloads, for example `{ success: false, error: { code: "NOT_FOUND", ... } }`. Those responses were being stringified as successful `CallToolResult`s, so MCP clients had to inspect the JSON body to know the tool failed.

This keeps the existing response body exactly the same and only adds `isError: true` when a handler returns an object with `success === false`. Successful tool payloads are still returned without `isError`, and thrown errors still go through the existing error normalization paths.

I added a registry-level regression test that captures the wrapper and verifies a logical `success: false` result is marked as an MCP error without calling `handleToolError`.

Checks run:

- `npm ci`
- `npm test -- tests/unit/tools/registry.test.ts`
- `npm run build`
- `npm test`
- `npm run test:coverage`
- `git diff --check`

Note: `npm ci` reports existing dependency audit findings, but this change does not touch dependencies or the lockfile.