### PR TITLE
Cap retry delay after adding jitter

### DIFF
--- a/src/servicenow/retry.ts
+++ b/src/servicenow/retry.ts
@@ -34,13 +34,11 @@ function calculateDelay(
   options: Required<RetryOptions>,
   retryAfterMs?: number
 ): number {
-  const exponentialDelay = Math.min(
-    options.initialDelayMs * Math.pow(options.backoffMultiplier, attempt),
-    options.maxDelayMs
-  );
+  const exponentialDelay =
+    options.initialDelayMs * Math.pow(options.backoffMultiplier, attempt);
   // Add 0-20% jitter
   const jitter = exponentialDelay * (Math.random() * 0.2);
-  const calculatedDelay = exponentialDelay + jitter;
+  const calculatedDelay = Math.min(exponentialDelay + jitter, options.maxDelayMs);
   // Honor Retry-After if present and larger
   if (retryAfterMs !== undefined && retryAfterMs > calculatedDelay) {
     return retryAfterMs;

--- a/tests/unit/servicenow/retry.test.ts
+++ b/tests/unit/servicenow/retry.test.ts
@@ -352,15 +352,15 @@ describe("withRetry", () => {
       maxDelayMs: 5000,
     });
 
-    // initialDelayMs (50000) > maxDelayMs (5000), so capped at 5000 + 10% jitter = 5500
-    await vi.advanceTimersByTimeAsync(5500);
+    // initialDelayMs (50000) plus jitter exceeds maxDelayMs, so final delay stays capped.
+    await vi.advanceTimersByTimeAsync(5000);
 
     const result = await promise;
 
     expect(result).toBe("ok");
     expect(loggerMocks.warn).toHaveBeenCalledWith(
       expect.objectContaining({
-        delayMs: 5500,
+        delayMs: 5000,
       }),
       "Retrying ServiceNow API call"
     );


### PR DESCRIPTION
Fixes #36.

The retry delay calculation was capping the exponential backoff first, then adding jitter on top. When the exponential delay was already at `maxDelayMs`, the final timeout could still exceed the configured cap by up to 20%.

This moves the cap to the final calculated delay, after jitter is added. `Retry-After` handling is left as-is: if the API sends a larger retry-after value, the wrapper still honors that explicit server hint.

I also updated the existing retry unit test so it now asserts the capped value stays at `maxDelayMs` instead of accepting `maxDelayMs + jitter`.

Checks run:

- `npm ci`
- `npm test -- tests/unit/servicenow/retry.test.ts`
- `npm run build`
- `npm test`
- `npm run test:coverage`
- `git diff --check`

Note: `npm ci` reports existing dependency audit findings, but this change does not touch dependencies or the lockfile.