### PR TITLE
fix: mark logical tool failures as MCP errors

### DIFF
--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -44,6 +44,15 @@ export function buildRecordUrl(
   return `${instanceUrl}/${table}.do?sys_id=${sysId}`;
 }
 
+function isLogicalToolFailure(result: unknown): boolean {
+  return (
+    typeof result === "object" &&
+    result !== null &&
+    "success" in result &&
+    (result as { success?: unknown }).success === false
+  );
+}
+
 export function registerAllTools(
   server: McpServer,
   config: Config,
@@ -102,7 +111,13 @@ export function registerAllTools(
           { userName: ctx.userName, duration },
           "Tool call completed"
         );
-        return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+        const response = {
+          content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+        };
+        if (isLogicalToolFailure(result)) {
+          return { ...response, isError: true };
+        }
+        return response;
       } catch (err: unknown) {
         const toolErr = (err as { toolError?: unknown })?.toolError;
         if (toolErr) {

--- a/tests/unit/tools/registry.test.ts
+++ b/tests/unit/tools/registry.test.ts
@@ -309,6 +309,40 @@ describe("registerAllTools", () => {
     expect(mocks.handleToolError).not.toHaveBeenCalled();
   });
 
+  it("marks logical tool failures as MCP errors", async () => {
+    registerAllTools(
+      {} as any,
+      config as any,
+      {} as any,
+      tokenStore as any
+    );
+
+    const logicalFailure = {
+      success: false,
+      error: {
+        code: "NOT_FOUND",
+        message: "Incident not found",
+        reference_id: "ref-404",
+      },
+    };
+
+    const wrapped = capturedWrap(async () => logicalFailure);
+
+    const extra = {
+      authInfo: {
+        token: "mcp-token-123",
+        clientId: "client-1",
+        scopes: [] as string[],
+        extra: { userSysId: "abc123def456abc123def456abc12345" },
+      },
+    };
+
+    const response = await wrapped({} as Record<string, never>, extra);
+
+    expect(response.isError).toBe(true);
+    expect(JSON.parse(response.content[0].text)).toEqual(logicalFailure);
+  });
+
   it("normalizes unexpected errors using handleToolError", async () => {
     registerAllTools(
       {} as any,


### PR DESCRIPTION
## Summary
- mark wrapped tool results with `success: false` as MCP errors
- preserve the existing JSON response content
- add a registry wrapper regression test for logical failures

Closes #61.

## Checks
- `npm test -- tests/unit/tools/registry.test.ts`
- `npm run build`
- `npm test`