### PR TITLE
Add incident search filters: major incident state, dates, and more

### DIFF
--- a/docs/tools/incidents.md
+++ b/docs/tools/incidents.md
@@ -13,12 +13,24 @@ Search for incidents with various filters. Returns a paginated summary list.
 | `query` | string | No | Free-text search in short description |
 | `state` | string | No | Filter by state (e.g., `New`, `In Progress`, `Resolved`) |
 | `priority` | string | No | Filter by priority (`1`-`5`) |
+| `impact` | string | No | Filter by impact (`1`=High, `2`=Medium, `3`=Low) |
+| `urgency` | string | No | Filter by urgency (`1`=High, `2`=Medium, `3`=Low) |
+| `major_incident_state` | string | No | Filter by major incident state choice value (e.g., `proposed`, `accepted`, `rejected`, `canceled`); case-insensitive. `any` matches incidents with any major incident state set; `none` matches incidents never proposed as major |
+| `category` | string | No | Filter by category (exact choice value) |
+| `subcategory` | string | No | Filter by subcategory (exact choice value) |
+| `caller` | string | No | Filter by caller name (contains match) |
+| `assigned_to` | string | No | Filter by assignee name (contains match) |
 | `assigned_to_me` | boolean | No | Only show incidents assigned to the authenticated user |
 | `assignment_group` | string | No | Filter by assignment group name |
+| `cmdb_ci` | string | No | Filter by configuration item (matches CI name or sys_id) |
+| `parent_incident` | string | No | Filter by parent incident (INC number or sys_id), e.g. to list children of a major incident |
+| `active` | boolean | No | Filter by active flag (`true` = open, `false` = closed/canceled) |
+| `opened_at_from` / `opened_at_to` | string | No | Opened-at range (YYYY-MM-DD or ISO 8601, inclusive; date-only upper bounds treated as end-of-day UTC) |
+| `resolved_at_from` / `resolved_at_to` | string | No | Resolved-at range (YYYY-MM-DD or ISO 8601, inclusive; date-only upper bounds treated as end-of-day UTC) |
 | `limit` | number | No | Maximum results (1-100, default 10) |
 | `offset` | number | No | Result offset for pagination (default 0) |
 
-**Returns**: Array of incident summaries with `sys_id`, `number`, `short_description`, `state`, `priority`, `impact`, `urgency`, `assigned_to`, `assignment_group`, `caller_id`, `category`, `opened_at`, `sys_updated_on`, and `self_link`.
+**Returns**: Array of incident summaries with `sys_id`, `number`, `short_description`, `state`, `priority`, `impact`, `urgency`, `major_incident_state`, `assigned_to`, `assignment_group`, `caller_id`, `category`, `subcategory`, `cmdb_ci`, `parent_incident`, `opened_at`, `resolved_at`, `sys_updated_on`, and `self_link`.
 
 ## `get_incident`
 

--- a/src/servicenow/types.ts
+++ b/src/servicenow/types.ts
@@ -21,6 +21,9 @@ export interface Incident extends ServiceNowRecord {
   assignment_group: string;
   caller_id: string;
   cmdb_ci?: string;
+  active?: string;
+  major_incident_state?: string;
+  parent_incident?: string;
   opened_at: string;
   opened_by: string;
   resolved_at?: string;

--- a/src/tools/incidents.ts
+++ b/src/tools/incidents.ts
@@ -11,6 +11,7 @@ import {
   validateSysId,
   validateIncidentNumber,
   sanitizeUpdatePayload,
+  normalizeDateBoundary,
 } from "../utils/validators.js";
 import { sanitizeValue } from "../servicenow/queryBuilder.js";
 
@@ -42,6 +43,36 @@ export function registerIncidentTools(
         .string()
         .optional()
         .describe("Filter by priority (1-5)"),
+      impact: z
+        .string()
+        .optional()
+        .describe("Filter by impact (1=High, 2=Medium, 3=Low)"),
+      urgency: z
+        .string()
+        .optional()
+        .describe("Filter by urgency (1=High, 2=Medium, 3=Low)"),
+      major_incident_state: z
+        .string()
+        .optional()
+        .describe(
+          "Filter by major incident state (choice value, e.g. 'proposed', 'accepted', 'rejected', 'canceled'). Use 'any' for incidents with any major incident state set, or 'none' for incidents that were never proposed as major."
+        ),
+      category: z
+        .string()
+        .optional()
+        .describe("Filter by category (exact choice value)"),
+      subcategory: z
+        .string()
+        .optional()
+        .describe("Filter by subcategory (exact choice value)"),
+      caller: z
+        .string()
+        .optional()
+        .describe("Filter by caller name"),
+      assigned_to: z
+        .string()
+        .optional()
+        .describe("Filter by assignee name"),
       assigned_to_me: z
         .boolean()
         .optional()
@@ -51,6 +82,36 @@ export function registerIncidentTools(
         .string()
         .optional()
         .describe("Filter by assignment group name"),
+      cmdb_ci: z
+        .string()
+        .optional()
+        .describe("Filter by configuration item (matches CI name or sys_id)"),
+      parent_incident: z
+        .string()
+        .optional()
+        .describe(
+          "Filter by parent incident (INC number or sys_id), e.g. to list children of a major incident"
+        ),
+      active: z
+        .boolean()
+        .optional()
+        .describe("Filter by active flag (true = open, false = closed/canceled)"),
+      opened_at_from: z
+        .string()
+        .optional()
+        .describe("Opened-at lower bound (YYYY-MM-DD or ISO 8601, inclusive)"),
+      opened_at_to: z
+        .string()
+        .optional()
+        .describe("Opened-at upper bound (YYYY-MM-DD or ISO 8601, inclusive; date-only treated as end-of-day UTC)"),
+      resolved_at_from: z
+        .string()
+        .optional()
+        .describe("Resolved-at lower bound (YYYY-MM-DD or ISO 8601, inclusive)"),
+      resolved_at_to: z
+        .string()
+        .optional()
+        .describe("Resolved-at upper bound (YYYY-MM-DD or ISO 8601, inclusive; date-only treated as end-of-day UTC)"),
       limit: z
         .number()
         .int()
@@ -67,8 +128,22 @@ export function registerIncidentTools(
           query?: string;
           state?: string;
           priority?: string;
+          impact?: string;
+          urgency?: string;
+          major_incident_state?: string;
+          category?: string;
+          subcategory?: string;
+          caller?: string;
+          assigned_to?: string;
           assigned_to_me?: boolean;
           assignment_group?: string;
+          cmdb_ci?: string;
+          parent_incident?: string;
+          active?: boolean;
+          opened_at_from?: string;
+          opened_at_to?: string;
+          resolved_at_from?: string;
+          resolved_at_to?: string;
           limit: number;
           offset: number;
         }
@@ -84,11 +159,84 @@ export function registerIncidentTools(
         if (args.priority) {
           queryParts.push(`priority=${sanitizeValue(args.priority)}`);
         }
+        if (args.impact) {
+          queryParts.push(`impact=${sanitizeValue(args.impact)}`);
+        }
+        if (args.urgency) {
+          queryParts.push(`urgency=${sanitizeValue(args.urgency)}`);
+        }
+        if (args.major_incident_state) {
+          // Choice values are stored lowercase (proposed, accepted, ...);
+          // normalize so display-cased input like "Accepted" still matches.
+          const mis = args.major_incident_state.trim().toLowerCase();
+          if (mis === "any") {
+            queryParts.push("major_incident_stateISNOTEMPTY");
+          } else if (mis === "none") {
+            queryParts.push("major_incident_stateISEMPTY");
+          } else {
+            queryParts.push(`major_incident_state=${sanitizeValue(mis)}`);
+          }
+        }
+        if (args.category) {
+          queryParts.push(`category=${sanitizeValue(args.category)}`);
+        }
+        if (args.subcategory) {
+          queryParts.push(`subcategory=${sanitizeValue(args.subcategory)}`);
+        }
+        if (args.caller) {
+          queryParts.push(`caller_idLIKE${sanitizeValue(args.caller)}`);
+        }
+        if (args.assigned_to) {
+          queryParts.push(`assigned_toLIKE${sanitizeValue(args.assigned_to)}`);
+        }
         if (args.assigned_to_me) {
           queryParts.push(`assigned_to=${ctx.userSysId}`);
         }
         if (args.assignment_group) {
           queryParts.push(`assignment_groupLIKE${sanitizeValue(args.assignment_group)}`);
+        }
+        if (args.cmdb_ci) {
+          queryParts.push(`cmdb_ciLIKE${sanitizeValue(args.cmdb_ci)}`);
+        }
+        if (args.parent_incident) {
+          if (validateSysId(args.parent_incident)) {
+            queryParts.push(`parent_incident=${args.parent_incident}`);
+          } else if (validateIncidentNumber(args.parent_incident)) {
+            queryParts.push(`parent_incident.number=${args.parent_incident}`);
+          } else {
+            return {
+              success: false,
+              error: {
+                code: "VALIDATION_ERROR",
+                message:
+                  "Invalid parent_incident. Provide an incident number (INC...) or a 32-character sys_id.",
+              },
+            };
+          }
+        }
+        if (args.active !== undefined) {
+          queryParts.push(`active=${args.active ? "true" : "false"}`);
+        }
+
+        const dateFilters: Array<[string, string | undefined, "from" | "to", string]> = [
+          ["opened_at", args.opened_at_from, "from", ">="],
+          ["opened_at", args.opened_at_to, "to", "<="],
+          ["resolved_at", args.resolved_at_from, "from", ">="],
+          ["resolved_at", args.resolved_at_to, "to", "<="],
+        ];
+        for (const [field, raw, boundary, op] of dateFilters) {
+          if (!raw) continue;
+          const normalized = normalizeDateBoundary(raw, boundary);
+          if (!normalized) {
+            return {
+              success: false,
+              error: {
+                code: "VALIDATION_ERROR",
+                message: `Invalid date for ${field}_${boundary}: ${raw}. Use YYYY-MM-DD or ISO 8601.`,
+              },
+            };
+          }
+          queryParts.push(`${field}${op}${sanitizeValue(normalized)}`);
         }
 
         queryParts.push("ORDERBYDESCsys_updated_on");
@@ -101,7 +249,7 @@ export function registerIncidentTools(
             sysparm_limit: args.limit,
             sysparm_offset: args.offset,
             sysparm_fields:
-              "sys_id,number,short_description,state,priority,impact,urgency,assigned_to,assignment_group,caller_id,category,opened_at,sys_updated_on",
+              "sys_id,number,short_description,state,priority,impact,urgency,major_incident_state,assigned_to,assignment_group,caller_id,category,subcategory,cmdb_ci,parent_incident,opened_at,resolved_at,sys_updated_on",
           },
         });
 

--- a/tests/unit/tools/incidents.test.ts
+++ b/tests/unit/tools/incidents.test.ts
@@ -76,7 +76,7 @@ describe("registerIncidentTools", () => {
         sysparm_limit: 10,
         sysparm_offset: 0,
         sysparm_fields:
-          "sys_id,number,short_description,state,priority,impact,urgency,assigned_to,assignment_group,caller_id,category,opened_at,sys_updated_on",
+          "sys_id,number,short_description,state,priority,impact,urgency,major_incident_state,assigned_to,assignment_group,caller_id,category,subcategory,cmdb_ci,parent_incident,opened_at,resolved_at,sys_updated_on",
       },
     });
     expect(result.success).toBe(true);
@@ -227,8 +227,17 @@ describe("registerIncidentTools", () => {
       query: "VPN",
       state: "New",
       priority: "1",
+      impact: "2",
+      urgency: "3",
+      major_incident_state: "accepted",
+      category: "Network",
+      subcategory: "VPN",
+      caller: "Jane Smith",
+      assigned_to: "John Doe",
       assigned_to_me: true,
       assignment_group: "Network",
+      cmdb_ci: "VPN Gateway",
+      active: true,
       limit: 5,
       offset: 10,
     });
@@ -238,8 +247,174 @@ describe("registerIncidentTools", () => {
     expect(query).toContain("short_descriptionLIKEVPN");
     expect(query).toContain("state=New");
     expect(query).toContain("priority=1");
+    expect(query).toContain("impact=2");
+    expect(query).toContain("urgency=3");
+    expect(query).toContain("major_incident_state=accepted");
+    expect(query).toContain("category=Network");
+    expect(query).toContain("subcategory=VPN");
+    expect(query).toContain("caller_idLIKEJane Smith");
+    expect(query).toContain("assigned_toLIKEJohn Doe");
     expect(query).toContain(`assigned_to=${userSysId}`);
     expect(query).toContain("assignment_groupLIKENetwork");
+    expect(query).toContain("cmdb_ciLIKEVPN Gateway");
+    expect(query).toContain("active=true");
+  });
+
+  it("search_incidents normalizes major_incident_state casing and maps any/none", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.get.mockResolvedValue({
+      data: { result: [] },
+      headers: { "x-total-count": "0" },
+    });
+
+    await handlers.search_incidents({
+      major_incident_state: " Accepted ",
+      limit: 10,
+      offset: 0,
+    });
+    expect(snClient.get.mock.calls[0][1].params.sysparm_query).toContain(
+      "major_incident_state=accepted"
+    );
+
+    await handlers.search_incidents({
+      major_incident_state: "any",
+      limit: 10,
+      offset: 0,
+    });
+    expect(snClient.get.mock.calls[1][1].params.sysparm_query).toContain(
+      "major_incident_stateISNOTEMPTY"
+    );
+
+    await handlers.search_incidents({
+      major_incident_state: "None",
+      limit: 10,
+      offset: 0,
+    });
+    expect(snClient.get.mock.calls[2][1].params.sysparm_query).toContain(
+      "major_incident_stateISEMPTY"
+    );
+  });
+
+  it("search_incidents filters by parent_incident sys_id or number", async () => {
+    const { handlers, snClient } = setup();
+    const parentSysId = "0123456789abcdef0123456789abcdef";
+
+    snClient.get.mockResolvedValue({
+      data: { result: [] },
+      headers: { "x-total-count": "0" },
+    });
+
+    await handlers.search_incidents({
+      parent_incident: parentSysId,
+      limit: 10,
+      offset: 0,
+    });
+    expect(snClient.get.mock.calls[0][1].params.sysparm_query).toContain(
+      `parent_incident=${parentSysId}`
+    );
+
+    await handlers.search_incidents({
+      parent_incident: "INC0012345",
+      limit: 10,
+      offset: 0,
+    });
+    expect(snClient.get.mock.calls[1][1].params.sysparm_query).toContain(
+      "parent_incident.number=INC0012345"
+    );
+  });
+
+  it("search_incidents returns VALIDATION_ERROR for invalid parent_incident", async () => {
+    const { handlers, snClient } = setup();
+
+    const result = (await handlers.search_incidents({
+      parent_incident: "not-a-ticket",
+      limit: 10,
+      offset: 0,
+    })) as any;
+
+    expect(result.success).toBe(false);
+    expect(result.error.code).toBe("VALIDATION_ERROR");
+    expect(snClient.get).not.toHaveBeenCalled();
+  });
+
+  it("search_incidents includes active=false and omits active when undefined", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.get.mockResolvedValue({
+      data: { result: [] },
+      headers: { "x-total-count": "0" },
+    });
+
+    await handlers.search_incidents({ active: false, limit: 10, offset: 0 });
+    expect(snClient.get.mock.calls[0][1].params.sysparm_query).toContain(
+      "active=false"
+    );
+
+    await handlers.search_incidents({ limit: 10, offset: 0 });
+    expect(snClient.get.mock.calls[1][1].params.sysparm_query).not.toContain(
+      "active="
+    );
+  });
+
+  it("search_incidents normalizes opened_at and resolved_at date bounds", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.get.mockResolvedValue({
+      data: { result: [] },
+      headers: { "x-total-count": "0" },
+    });
+
+    await handlers.search_incidents({
+      opened_at_from: "2026-07-01",
+      opened_at_to: "2026-07-14",
+      resolved_at_from: "2026-07-02T08:30:00Z",
+      limit: 10,
+      offset: 0,
+    });
+
+    const query = snClient.get.mock.calls[0][1].params.sysparm_query;
+    expect(query).toContain("opened_at>=2026-07-01 00:00:00");
+    expect(query).toContain("opened_at<=2026-07-14 23:59:59");
+    expect(query).toContain("resolved_at>=2026-07-02 08:30:00");
+  });
+
+  it("search_incidents returns VALIDATION_ERROR for invalid date bounds", async () => {
+    const { handlers, snClient } = setup();
+
+    const result = (await handlers.search_incidents({
+      opened_at_from: "not-a-date",
+      limit: 10,
+      offset: 0,
+    })) as any;
+
+    expect(result.success).toBe(false);
+    expect(result.error.code).toBe("VALIDATION_ERROR");
+    expect(result.error.message).toContain("opened_at_from");
+    expect(snClient.get).not.toHaveBeenCalled();
+  });
+
+  it("search_incidents escapes injection characters in new filters", async () => {
+    const { handlers, snClient } = setup();
+
+    snClient.get.mockResolvedValue({
+      data: { result: [] },
+      headers: { "x-total-count": "0" },
+    });
+
+    await handlers.search_incidents({
+      major_incident_state: "accepted^nqstate=7",
+      category: "help^nq",
+      caller: "smith,jones",
+      limit: 10,
+      offset: 0,
+    });
+
+    const query = snClient.get.mock.calls[0][1].params.sysparm_query;
+    expect(query).toContain("major_incident_state=accepted\\^nqstate=7");
+    expect(query).toContain("category=help\\^nq");
+    expect(query).toContain("caller_idLIKEsmith\\,jones");
+    expect(query).not.toMatch(/[^\\]\^nq/i);
   });
 
   it("search_incidents escapes encoded query injection characters in query", async () => {


### PR DESCRIPTION
## Summary

`search_incidents` previously supported only `query`, `state`, `priority`, `assigned_to_me`, and `assignment_group`. This PR extends it with the filters users keep asking for — most notably **major incident state** — following the same patterns already established in `search_change_requests`.

### New filters

| Filter | Behavior |
|---|---|
| `major_incident_state` | Matches the choice value (case-insensitive, e.g. `proposed`, `accepted`, `rejected`, `canceled`). Special values: `any` → `ISNOTEMPTY`, `none` → `ISEMPTY` |
| `impact`, `urgency` | Exact value (1–3) |
| `category`, `subcategory` | Exact choice value |
| `caller`, `assigned_to` | Contains match on the reference display value (same pattern as the existing `assignment_group` filter) |
| `cmdb_ci` | Contains match (same as `search_change_requests`) |
| `parent_incident` | INC number (via `parent_incident.number=` dot-walk) or sys_id; useful for listing children of a major incident. Invalid input returns `VALIDATION_ERROR` |
| `active` | Boolean flag (`false` is honored, not dropped) |
| `opened_at_from/to`, `resolved_at_from/to` | Inclusive date ranges via `normalizeDateBoundary` (date-only upper bounds pinned to end-of-day UTC), same as change requests |

### Other changes

- Summary results now include `major_incident_state`, `subcategory`, `cmdb_ci`, `parent_incident`, and `resolved_at`.
- `Incident` type gains explicit `active`, `major_incident_state`, `parent_incident` fields.
- Docs updated in `docs/tools/incidents.md`.

All new string filters go through `sanitizeValue` (encoded-query escaping), with injection tests covering the new paths.

Read-only change: only the search tool's query building is affected; no write paths touched.

## Testing

- `npm run build` — clean
- `npm run test:coverage` — 421 tests / 37 files passing, thresholds intact (7 new tests covering the new filters, `any`/`none` mapping, parent-incident validation, date-bound normalization/validation, and query escaping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)