### PR TITLE
Add per-tool usage metrics: logging, Redis counters, /metrics/usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,9 @@ LOG_LEVEL=info
 # Rate Limiting
 RATE_LIMIT_PER_USER=60
 
+# Usage metrics endpoint (optional — GET /metrics/usage is disabled when unset; min 16 chars)
+# METRICS_TOKEN=
+
 # TLS (optional — omit if terminating TLS at a reverse proxy)
 # TLS_CERT_PATH=/certs/server.crt
 # TLS_KEY_PATH=/certs/server.key

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Result: safer automation, cleaner compliance, fewer permission hacks.
 - Tool-level identity protections for sensitive operations
 - Per-user rate limiting via Redis token bucket
 - Input validation + normalized error responses
+- Per-tool/per-user usage metrics in Redis with an optional token-gated `/metrics/usage` endpoint
 - CI-enforced build + test + coverage gate
 
 ---

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -2,13 +2,13 @@
 
 # HTTP API
 
-The server exposes 8 HTTP endpoints: a health check, OAuth routes, and the MCP transport endpoint.
+The server exposes 9 HTTP endpoints: a health check, an optional usage-metrics endpoint, OAuth routes, and the MCP transport endpoint.
 
 ## Section Index
 
 | Guide | Description |
 |---|---|
-| [Endpoints](./endpoints.md) | All 8 endpoints with request/response details |
+| [Endpoints](./endpoints.md) | All 9 endpoints with request/response details |
 | [Client Configuration](./client-configuration.md) | Claude Desktop JSON config examples |
 
 ## Overview
@@ -20,7 +20,7 @@ The server uses **Streamable HTTP** as its MCP transport. This means:
 - `DELETE /mcp` closes a session
 - Sessions are identified by the `Mcp-Session-Id` header
 
-All other endpoints (`/health`, `/oauth/*`) are standard REST.
+All other endpoints (`/health`, `/metrics/usage`, `/oauth/*`) are standard REST.
 
 ---
 

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -29,6 +29,40 @@ Returns server health status including Redis connectivity.
 
 ---
 
+## Usage Metrics
+
+### `GET /metrics/usage`
+
+Aggregated per-tool/per-user usage counters. Only registered when `METRICS_TOKEN` is set; requires that token as a bearer credential.
+
+**Query parameters**: `days` — window size in days ending today (default `30`, clamped to `1`–`400`).
+
+**Request**:
+```bash
+curl -s -H "Authorization: Bearer $METRICS_TOKEN" \
+  "https://your-mcp-host:8080/metrics/usage?days=30"
+```
+
+**Response (200)**:
+```json
+{
+  "days": 30,
+  "from": "2026-06-18",
+  "to": "2026-07-17",
+  "totals": { "calls": 120, "errors": 3 },
+  "byTool": { "lookup_user": { "calls": 40, "errors": 1 } },
+  "byUser": { "john.doe": { "calls": 80, "errors": 2 } },
+  "byDay": { "2026-07-17": { "calls": 12, "errors": 0 } },
+  "byToolUser": { "lookup_user": { "john.doe": { "calls": 25, "errors": 1 } } }
+}
+```
+
+**Response (401)** — missing or wrong bearer token. **Response (404)** — `METRICS_TOKEN` not configured.
+
+Counters live in Redis (see [Redis Schema](../architecture/redis-schema.md)), so they survive app redeploys; only calls that resolved an authenticated user are counted.
+
+---
+
 ## MCP-Spec OAuth
 
 The server implements MCP-spec OAuth 2.0 with PKCE. MCP clients discover endpoints automatically via `GET /.well-known/oauth-authorization-server`. The following endpoints are handled by the SDK's built-in middleware:

--- a/docs/architecture/redis-schema.md
+++ b/docs/architecture/redis-schema.md
@@ -122,6 +122,17 @@ Long-lived refresh token for obtaining new MCP access tokens.
 | **Set by** | `ServiceNowOAuthProvider.exchangeAuthorizationCode()` |
 | **Read by** | `ServiceNowOAuthProvider.exchangeRefreshToken()` |
 
+### 10. `metrics:calls:<YYYY-MM-DD>` / `metrics:errors:<YYYY-MM-DD>` — Usage Counters
+
+Per-day (UTC) tool-usage counters. Hash fields are `<toolName>|<userName>`; values are call counts. `metrics:calls:*` counts successful calls, `metrics:errors:*` failed ones. Only calls that resolved an authenticated user context are recorded, and increments are fire-and-forget so metrics can never fail a tool call.
+
+| Field | Value |
+|---|---|
+| **Type** | Hash (`<toolName>\|<userName>` → count) |
+| **TTL** | 34,560,000 seconds (400 days), set on first increment |
+| **Set by** | `UsageMetrics.record()` (called from the tool `wrapHandler`) |
+| **Read by** | `UsageMetrics.summary()` (`GET /metrics/usage`) |
+
 ## Summary Table
 
 | Key Pattern | Type | TTL | Purpose |
@@ -135,6 +146,8 @@ Long-lived refresh token for obtaining new MCP access tokens.
 | `auth_code:<code>` | String (JSON) | 5 min | MCP authorization codes |
 | `mcp_token:<token>` | String (JSON) | 1 hour | MCP access tokens |
 | `mcp_refresh:<token>` | String (JSON) | 30 days | MCP refresh tokens |
+| `metrics:calls:<date>` | Hash | 400 days | Successful tool calls per tool/user/day |
+| `metrics:errors:<date>` | Hash | 400 days | Failed tool calls per tool/user/day |
 
 ---
 

--- a/docs/deployment/environment-variables.md
+++ b/docs/deployment/environment-variables.md
@@ -28,6 +28,7 @@ Full configuration reference. All variables are validated at startup by Zod (`sr
 | `TLS_CERT_PATH` | — | Path to TLS certificate. Must pair with `TLS_KEY_PATH`. See [Native TLS](./native-tls.md). |
 | `TLS_KEY_PATH` | — | Path to TLS private key. Must pair with `TLS_CERT_PATH`. |
 | `CADDY_DOMAIN` | — | Domain for Caddy auto-TLS (used with `docker-compose.caddy.yml`). See [Docker (Caddy)](./docker-caddy.md). |
+| `METRICS_TOKEN` | — | Bearer token for `GET /metrics/usage`. The endpoint is disabled when unset. See [Endpoints](../api/endpoints.md). |
 
 ## Validation Rules
 
@@ -38,6 +39,7 @@ Full configuration reference. All variables are validated at startup by Zod (`sr
 - `MCP_PORT`, `RATE_LIMIT_PER_USER` must be positive integers
 - `MCP_SERVER_URL` must be a valid URL if set
 - `SN_CALLBACK_URI` must be a valid URL if set
+- `METRICS_TOKEN` must be at least 16 characters if set
 
 ## Example `.env`
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,11 @@ const configSchema = z.object({
     .enum(["fatal", "error", "warn", "info", "debug", "trace"])
     .default("info"),
   RATE_LIMIT_PER_USER: z.coerce.number().int().positive().default(60),
+  METRICS_TOKEN: z
+    .string()
+    .min(16, "METRICS_TOKEN must be at least 16 characters")
+    .optional()
+    .describe("Bearer token for the /metrics/usage endpoint; endpoint is disabled when unset"),
   TLS_CERT_PATH: z.string().optional(),
   TLS_KEY_PATH: z.string().optional(),
   ALLOWED_ORIGINS: z

--- a/src/metrics/usage.ts
+++ b/src/metrics/usage.ts
@@ -1,0 +1,133 @@
+import type { Redis } from "ioredis";
+import { logger } from "../utils/logger.js";
+
+const DAY_SECONDS = 86400;
+const DEFAULT_RETENTION_DAYS = 400;
+export const MAX_SUMMARY_DAYS = 400;
+
+export interface UsageCounts {
+  calls: number;
+  errors: number;
+}
+
+export interface UsageSummary {
+  days: number;
+  from: string;
+  to: string;
+  totals: UsageCounts;
+  byTool: Record<string, UsageCounts>;
+  byUser: Record<string, UsageCounts>;
+  byDay: Record<string, UsageCounts>;
+  byToolUser: Record<string, Record<string, UsageCounts>>;
+}
+
+function utcDay(offsetDays = 0): string {
+  return new Date(Date.now() - offsetDays * DAY_SECONDS * 1000)
+    .toISOString()
+    .slice(0, 10);
+}
+
+// "|" separates tool and user in hash fields, so strip it from inputs
+function sanitizeField(value: string): string {
+  return value.replaceAll("|", "_");
+}
+
+function emptyCounts(): UsageCounts {
+  return { calls: 0, errors: 0 };
+}
+
+/**
+ * Durable per-day usage counters in Redis. Counters survive app redeploys
+ * (unlike container logs) and expire after the retention window.
+ *
+ * Keys: metrics:calls:<YYYY-MM-DD> and metrics:errors:<YYYY-MM-DD> (UTC days),
+ * hash fields "<toolName>|<userName>" holding call counts.
+ */
+export class UsageMetrics {
+  constructor(
+    private redis: Redis,
+    private retentionDays: number = DEFAULT_RETENTION_DAYS
+  ) {}
+
+  private dayKey(kind: "calls" | "errors", day: string): string {
+    return `metrics:${kind}:${day}`;
+  }
+
+  /**
+   * Fire-and-forget increment; must never throw or delay a tool call.
+   * Only calls that resolved a user context are recorded.
+   */
+  record(toolName: string, userName: string, ok: boolean): void {
+    try {
+      const key = this.dayKey(ok ? "calls" : "errors", utcDay());
+      const field = `${sanitizeField(toolName)}|${sanitizeField(userName)}`;
+      this.redis
+        .multi()
+        .hincrby(key, field, 1)
+        .expire(key, this.retentionDays * DAY_SECONDS, "NX")
+        .exec()
+        .catch((err) => {
+          logger.debug({ err }, "Usage metrics increment failed");
+        });
+    } catch (err) {
+      logger.debug({ err }, "Usage metrics increment failed");
+    }
+  }
+
+  async summary(days: number): Promise<UsageSummary> {
+    const window = Math.min(Math.max(Math.trunc(days), 1), MAX_SUMMARY_DAYS);
+    const dayList: string[] = [];
+    for (let i = 0; i < window; i++) {
+      dayList.push(utcDay(i));
+    }
+
+    const pipeline = this.redis.pipeline();
+    for (const day of dayList) pipeline.hgetall(this.dayKey("calls", day));
+    for (const day of dayList) pipeline.hgetall(this.dayKey("errors", day));
+    const results = (await pipeline.exec()) ?? [];
+
+    const summary: UsageSummary = {
+      days: window,
+      from: dayList[dayList.length - 1],
+      to: dayList[0],
+      totals: emptyCounts(),
+      byTool: {},
+      byUser: {},
+      byDay: {},
+      byToolUser: {},
+    };
+
+    const ingest = (
+      day: string,
+      fields: Record<string, string>,
+      kind: keyof UsageCounts
+    ): void => {
+      for (const [field, raw] of Object.entries(fields)) {
+        const count = parseInt(raw, 10);
+        if (!Number.isFinite(count)) continue;
+        const [toolName, userName = "unknown"] = field.split("|");
+
+        summary.totals[kind] += count;
+        (summary.byTool[toolName] ??= emptyCounts())[kind] += count;
+        (summary.byUser[userName] ??= emptyCounts())[kind] += count;
+        (summary.byDay[day] ??= emptyCounts())[kind] += count;
+        ((summary.byToolUser[toolName] ??= {})[userName] ??= emptyCounts())[
+          kind
+        ] += count;
+      }
+    };
+
+    for (let i = 0; i < dayList.length; i++) {
+      const [callsErr, calls] = results[i] ?? [null, {}];
+      const [errorsErr, errors] = results[dayList.length + i] ?? [null, {}];
+      if (!callsErr && calls) {
+        ingest(dayList[i], calls as Record<string, string>, "calls");
+      }
+      if (!errorsErr && errors) {
+        ingest(dayList[i], errors as Record<string, string>, "errors");
+      }
+    }
+
+    return summary;
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,7 @@
 import express, { type Request, type Response } from "express";
 import cors from "cors";
 import helmet from "helmet";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID, timingSafeEqual } from "node:crypto";
 import type { Redis } from "ioredis";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
@@ -12,6 +12,7 @@ import { TokenStore } from "./auth/tokenStore.js";
 import { ServiceNowOAuthProvider } from "./auth/oauthProvider.js";
 import { createOAuthRouter } from "./auth/oauth.js";
 import { registerAllTools } from "./tools/registry.js";
+import { UsageMetrics, MAX_SUMMARY_DAYS } from "./metrics/usage.js";
 import { logger } from "./utils/logger.js";
 
 interface SessionEntry {
@@ -20,12 +21,20 @@ interface SessionEntry {
   createdAt: number;
 }
 
+function timingSafeEqualStrings(a: string, b: string): boolean {
+  // Hash both sides so inputs of different lengths still compare in constant time
+  const digestA = createHash("sha256").update(a).digest();
+  const digestB = createHash("sha256").update(b).digest();
+  return timingSafeEqual(digestA, digestB);
+}
+
 export async function createApp(
   config: Config,
   redis: Redis
 ): Promise<express.Express> {
   const app = express();
   const tokenStore = new TokenStore(redis, config.TOKEN_ENCRYPTION_KEY);
+  const usageMetrics = new UsageMetrics(redis);
 
   // OAuth provider for MCP SDK auth
   const oauthProvider = new ServiceNowOAuthProvider(config, tokenStore);
@@ -66,6 +75,27 @@ export async function createApp(
     }
   });
 
+  // Usage metrics endpoint — enabled only when METRICS_TOKEN is configured
+  if (config.METRICS_TOKEN) {
+    const expectedAuth = `Bearer ${config.METRICS_TOKEN}`;
+    app.get("/metrics/usage", async (req: Request, res: Response) => {
+      if (!timingSafeEqualStrings(req.headers.authorization ?? "", expectedAuth)) {
+        res.status(401).json({ error: "Unauthorized" });
+        return;
+      }
+      const daysParam = Number(req.query.days);
+      const days = Number.isFinite(daysParam)
+        ? Math.min(Math.max(Math.trunc(daysParam), 1), MAX_SUMMARY_DAYS)
+        : 30;
+      try {
+        res.json(await usageMetrics.summary(days));
+      } catch (err) {
+        logger.error({ err }, "Failed to build usage metrics summary");
+        res.status(500).json({ error: "Failed to build usage metrics summary" });
+      }
+    });
+  }
+
   // MCP SDK OAuth routes (/.well-known/*, /authorize, /token, /register, /revoke)
   app.use(
     mcpAuthRouter({
@@ -101,7 +131,7 @@ export async function createApp(
     });
 
     // Register all tools
-    registerAllTools(server, config, redis, tokenStore);
+    registerAllTools(server, config, redis, tokenStore, usageMetrics);
 
     // Clean up on transport close
     transport.onclose = () => {

--- a/src/tools/_template.ts
+++ b/src/tools/_template.ts
@@ -11,14 +11,7 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import type { ToolContext } from "./registry.js";
-
-type WrapHandler = <T>(
-  handler: (ctx: ToolContext, args: T) => Promise<unknown>
-) => (args: T) => Promise<{
-  content: { type: "text"; text: string }[];
-  isError?: boolean;
-}>;
+import type { ToolContext, WrapHandler } from "./registry.js";
 
 export function registerMyDomainTools(
   server: McpServer,
@@ -32,7 +25,7 @@ export function registerMyDomainTools(
       param1: z.string().describe("Description of param1"),
       param2: z.number().optional().describe("Optional numeric parameter"),
     },
-    wrapHandler(
+    wrapHandler("my_tool_name", 
       async (ctx: ToolContext, args: { param1: string; param2?: number }) => {
         // ctx.snClient is already authenticated as the calling user
         // ctx.userSysId, ctx.userName, ctx.displayName are available

--- a/src/tools/accessControl.ts
+++ b/src/tools/accessControl.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import type { ToolContext } from "./registry.js";
+import type { ToolContext, WrapHandler } from "./registry.js";
 import { buildRecordUrl } from "./registry.js";
 import type {
   ServiceNowListResponse,
@@ -8,13 +8,6 @@ import type {
 } from "../servicenow/types.js";
 import { sanitizeValue } from "../servicenow/queryBuilder.js";
 import { validateSysId } from "../utils/validators.js";
-
-type WrapHandler = <T>(
-  handler: (ctx: ToolContext, args: T) => Promise<unknown>
-) => (args: T) => Promise<{
-  content: { type: "text"; text: string }[];
-  isError?: boolean;
-}>;
 
 // Access controls (sys_security_acl). `name` is the table (e.g. 'incident') or
 // table.field (e.g. 'incident.state'); `operation` is read/write/create/delete;
@@ -80,7 +73,7 @@ export function registerAccessControlTools(
         .default(0)
         .describe("Result offset for pagination"),
     },
-    wrapHandler(
+    wrapHandler("search_acls", 
       async (
         ctx: ToolContext,
         args: {
@@ -148,7 +141,7 @@ export function registerAccessControlTools(
         .default(200)
         .describe("Maximum sys_security_acl_role rows to return"),
     },
-    wrapHandler(
+    wrapHandler("get_acl", 
       async (ctx: ToolContext, args: { sys_id: string; role_limit: number }) => {
         if (!validateSysId(args.sys_id)) {
           return {

--- a/src/tools/catalog.ts
+++ b/src/tools/catalog.ts
@@ -1,15 +1,8 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import type { ToolContext } from "./registry.js";
+import type { ToolContext, WrapHandler } from "./registry.js";
 import { buildRecordUrl } from "./registry.js";
 import { validateSysId } from "../utils/validators.js";
-
-type WrapHandler = <T>(
-  handler: (ctx: ToolContext, args: T) => Promise<unknown>
-) => (args: T) => Promise<{
-  content: { type: "text"; text: string }[];
-  isError?: boolean;
-}>;
 
 export function registerCatalogTools(
   server: McpServer,
@@ -29,7 +22,7 @@ export function registerCatalogTools(
         .default(10)
         .describe("Maximum results"),
     },
-    wrapHandler(async (ctx: ToolContext, args: { query: string; limit: number }) => {
+    wrapHandler("search_catalog_items", async (ctx: ToolContext, args: { query: string; limit: number }) => {
       const { data } = await ctx.snClient.get<{
         result: unknown[];
       }>("/api/sn_sc/servicecatalog/items", {
@@ -61,7 +54,7 @@ export function registerCatalogTools(
     {
       sys_id: z.string().describe("Catalog item sys_id"),
     },
-    wrapHandler(async (ctx: ToolContext, args: { sys_id: string }) => {
+    wrapHandler("get_catalog_item", async (ctx: ToolContext, args: { sys_id: string }) => {
       if (!validateSysId(args.sys_id)) {
         return {
           success: false,
@@ -98,7 +91,7 @@ export function registerCatalogTools(
         .describe("Form variable values as key-value pairs"),
       quantity: z.number().int().min(1).default(1).describe("Quantity to order"),
     },
-    wrapHandler(
+    wrapHandler("submit_catalog_request", 
       async (
         ctx: ToolContext,
         args: { sys_id: string; variables: Record<string, unknown>; quantity: number }

--- a/src/tools/catalogAdmin.ts
+++ b/src/tools/catalogAdmin.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import type { ToolContext } from "./registry.js";
+import type { ToolContext, WrapHandler } from "./registry.js";
 import { buildRecordUrl } from "./registry.js";
 import type {
   ServiceNowSingleResponse,
@@ -15,13 +15,6 @@ import type {
   CatalogItem,
 } from "../servicenow/types.js";
 import { validateSysId, validateIOVariable, sanitizeUpdatePayload } from "../utils/validators.js";
-
-type WrapHandler = <T>(
-  handler: (ctx: ToolContext, args: T) => Promise<unknown>
-) => (args: T) => Promise<{
-  content: { type: "text"; text: string }[];
-  isError?: boolean;
-}>;
 
 const VARIABLE_TYPE_MAP: Record<string, number> = {
   yes_no: 1,
@@ -92,7 +85,7 @@ export function registerCatalogAdminTools(
       no_quantity: z.boolean().optional().describe("Hide quantity selector"),
       workflow: z.string().optional().describe("Workflow sys_id"),
     },
-    wrapHandler(
+    wrapHandler("create_catalog_item", 
       async (
         ctx: ToolContext,
         args: {
@@ -153,7 +146,7 @@ export function registerCatalogAdminTools(
         .record(z.unknown())
         .describe("Fields to update (e.g. { active: false })"),
     },
-    wrapHandler(
+    wrapHandler("update_catalog_item", 
       async (
         ctx: ToolContext,
         args: { sys_id: string; fields: Record<string, unknown> }
@@ -216,7 +209,7 @@ export function registerCatalogAdminTools(
       attributes: z.string().optional().describe("Widget attributes (e.g. max_length=4)"),
       validate_regex: z.string().optional().describe("Regex validation — sys_id or name of a question_regex record (e.g. 'number')"),
     },
-    wrapHandler(
+    wrapHandler("create_catalog_variable", 
       async (
         ctx: ToolContext,
         args: {
@@ -296,7 +289,7 @@ export function registerCatalogAdminTools(
         .record(z.unknown())
         .describe("Fields to update"),
     },
-    wrapHandler(
+    wrapHandler("update_catalog_variable", 
       async (
         ctx: ToolContext,
         args: { sys_id: string; fields: Record<string, unknown> }
@@ -352,7 +345,7 @@ export function registerCatalogAdminTools(
         .default(50)
         .describe("Maximum results"),
     },
-    wrapHandler(
+    wrapHandler("list_catalog_variables", 
       async (
         ctx: ToolContext,
         args: {
@@ -475,7 +468,7 @@ export function registerCatalogAdminTools(
       value: z.string().min(1).describe("Stored value"),
       order: z.number().int().optional().describe("Display order"),
     },
-    wrapHandler(
+    wrapHandler("create_variable_choice", 
       async (
         ctx: ToolContext,
         args: {
@@ -537,7 +530,7 @@ export function registerCatalogAdminTools(
       description: z.string().optional().describe("Description"),
       order: z.number().int().optional().describe("Display order"),
     },
-    wrapHandler(
+    wrapHandler("create_variable_set", 
       async (
         ctx: ToolContext,
         args: {
@@ -587,7 +580,7 @@ export function registerCatalogAdminTools(
       variable_set: z.string().describe("Variable set sys_id"),
       order: z.number().int().optional().describe("Display order"),
     },
-    wrapHandler(
+    wrapHandler("attach_variable_set", 
       async (
         ctx: ToolContext,
         args: {
@@ -683,7 +676,7 @@ export function registerCatalogAdminTools(
         .optional()
         .describe("Applies on requested items (default false)"),
     },
-    wrapHandler(
+    wrapHandler("create_catalog_client_script", 
       async (
         ctx: ToolContext,
         args: {
@@ -817,7 +810,7 @@ export function registerCatalogAdminTools(
         .record(z.unknown())
         .describe("Fields to update (e.g. { active: false })"),
     },
-    wrapHandler(
+    wrapHandler("update_catalog_client_script", 
       async (
         ctx: ToolContext,
         args: { sys_id: string; fields: Record<string, unknown> }
@@ -900,7 +893,7 @@ export function registerCatalogAdminTools(
         .describe("JavaScript when condition false"),
       active: z.boolean().optional().describe("Active (default true)"),
     },
-    wrapHandler(
+    wrapHandler("create_catalog_ui_policy", 
       async (
         ctx: ToolContext,
         args: {
@@ -1032,7 +1025,7 @@ export function registerCatalogAdminTools(
         .optional()
         .describe("Clear value when hidden (default false)"),
     },
-    wrapHandler(
+    wrapHandler("create_catalog_ui_policy_action", 
       async (
         ctx: ToolContext,
         args: {

--- a/src/tools/changeRequests.ts
+++ b/src/tools/changeRequests.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import type { ToolContext } from "./registry.js";
+import type { ToolContext, WrapHandler } from "./registry.js";
 import { buildRecordUrl } from "./registry.js";
 import type {
   ServiceNowListResponse,
@@ -31,13 +31,6 @@ const ORDER_BY_MAP: Record<string, string> = {
 };
 
 const ORDER_BY_KEYS = Object.keys(ORDER_BY_MAP) as [string, ...string[]];
-
-type WrapHandler = <T>(
-  handler: (ctx: ToolContext, args: T) => Promise<unknown>
-) => (args: T) => Promise<{
-  content: { type: "text"; text: string }[];
-  isError?: boolean;
-}>;
 
 async function resolveChangeRequestSysId(
   ctx: ToolContext,
@@ -168,7 +161,7 @@ export function registerChangeRequestTools(
         .describe("Maximum results"),
       offset: z.number().int().min(0).default(0).describe("Result offset for pagination"),
     },
-    wrapHandler(
+    wrapHandler("search_change_requests", 
       async (
         ctx: ToolContext,
         args: {
@@ -286,7 +279,7 @@ export function registerChangeRequestTools(
         .string()
         .describe("Change number (e.g. CHG0012345) or sys_id"),
     },
-    wrapHandler(async (ctx: ToolContext, args: { identifier: string }) => {
+    wrapHandler("get_change_request", async (ctx: ToolContext, args: { identifier: string }) => {
       let path: string;
       let params: Record<string, string | number | boolean> = {};
 
@@ -355,7 +348,7 @@ export function registerChangeRequestTools(
       start_date: z.string().optional().describe("Planned start date (ISO 8601)"),
       end_date: z.string().optional().describe("Planned end date (ISO 8601)"),
     },
-    wrapHandler(
+    wrapHandler("create_change_request", 
       async (
         ctx: ToolContext,
         args: {
@@ -415,7 +408,7 @@ export function registerChangeRequestTools(
           "Fields to update (e.g. { state: 'Implement', assignment_group: 'CAB' })"
         ),
     },
-    wrapHandler(
+    wrapHandler("update_change_request", 
       async (
         ctx: ToolContext,
         args: { identifier: string; fields: Record<string, unknown> }
@@ -448,7 +441,7 @@ export function registerChangeRequestTools(
       identifier: z.string().describe("Change number (CHG...) or sys_id"),
       offset: z.number().int().min(0).default(0).describe("Starting offset for continuation when previous response was truncated"),
     },
-    wrapHandler(
+    wrapHandler("get_change_request_approvals", 
       async (ctx: ToolContext, args: { identifier: string; offset: number }) => {
         const resolved = await resolveChangeRequestSysId(ctx, args.identifier);
         if ("error" in resolved) return resolved.error;
@@ -504,7 +497,7 @@ export function registerChangeRequestTools(
         .default("work_note")
         .describe("work_note = internal, comment = customer-visible"),
     },
-    wrapHandler(
+    wrapHandler("add_change_request_work_note", 
       async (
         ctx: ToolContext,
         args: { identifier: string; note: string; type: "work_note" | "comment" }

--- a/src/tools/cmdb.ts
+++ b/src/tools/cmdb.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import type { ToolContext } from "./registry.js";
+import type { ToolContext, WrapHandler } from "./registry.js";
 import { buildRecordUrl } from "./registry.js";
 import type {
   ServiceNowListResponse,
@@ -8,13 +8,6 @@ import type {
 } from "../servicenow/types.js";
 import { sanitizeValue } from "../servicenow/queryBuilder.js";
 import { validateSysId, normalizeDateBoundary } from "../utils/validators.js";
-
-type WrapHandler = <T>(
-  handler: (ctx: ToolContext, args: T) => Promise<unknown>
-) => (args: T) => Promise<{
-  content: { type: "text"; text: string }[];
-  isError?: boolean;
-}>;
 
 // cmdb_ci is the parent CMDB table; every CI class (cmdb_ci_server,
 // cmdb_ci_db_instance, cmdb_ci_appl, …) extends it, so querying the parent
@@ -162,7 +155,7 @@ export function registerCmdbTools(
         .default(0)
         .describe("Result offset for pagination"),
     },
-    wrapHandler(
+    wrapHandler("search_cis", 
       async (
         ctx: ToolContext,
         args: {
@@ -262,7 +255,7 @@ export function registerCmdbTools(
         .string()
         .describe("Configuration item sys_id (32 hex chars)"),
     },
-    wrapHandler(async (ctx: ToolContext, args: { sys_id: string }) => {
+    wrapHandler("get_ci", async (ctx: ToolContext, args: { sys_id: string }) => {
       if (!validateSysId(args.sys_id)) {
         return {
           success: false,
@@ -307,7 +300,7 @@ export function registerCmdbTools(
         .default(200)
         .describe("Maximum relationship rows per direction"),
     },
-    wrapHandler(
+    wrapHandler("get_ci_relationships", 
       async (
         ctx: ToolContext,
         args: { sys_id: string; limit: number }
@@ -379,7 +372,7 @@ export function registerCmdbTools(
     "count_cis_by_class",
     "Aggregate the entire CMDB by class via the ServiceNow Aggregate API (/api/now/stats/cmdb_ci grouped by sys_class_name with counts). One call returns the shape of the whole CMDB: a count per CI class sorted by count descending, plus the grand total and number of populated classes.",
     {},
-    wrapHandler(async (ctx: ToolContext) => {
+    wrapHandler("count_cis_by_class", async (ctx: ToolContext) => {
       const { data } = await ctx.snClient.get<{
         result: AggregateGroup[] | AggregateGroup;
       }>(`/api/now/stats/${CI_TABLE}`, {
@@ -469,7 +462,7 @@ export function registerCmdbTools(
         .default(0)
         .describe("Result offset for pagination"),
     },
-    wrapHandler(
+    wrapHandler("find_stale_cis", 
       async (
         ctx: ToolContext,
         args: {
@@ -565,7 +558,7 @@ export function registerCmdbTools(
           "Most-recent sample records to return per ticket type (0 = counts only)"
         ),
     },
-    wrapHandler(
+    wrapHandler("get_ci_ticket_references", 
       async (
         ctx: ToolContext,
         args: { sys_id: string; sample_limit: number }

--- a/src/tools/flowLogs.ts
+++ b/src/tools/flowLogs.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import type { ToolContext } from "./registry.js";
+import type { ToolContext, WrapHandler } from "./registry.js";
 import { buildRecordUrl } from "./registry.js";
 import type {
   ServiceNowListResponse,
@@ -8,13 +8,6 @@ import type {
 } from "../servicenow/types.js";
 import { sanitizeValue } from "../servicenow/queryBuilder.js";
 import { validateSysId, normalizeDateBoundary } from "../utils/validators.js";
-
-type WrapHandler = <T>(
-  handler: (ctx: ToolContext, args: T) => Promise<unknown>
-) => (args: T) => Promise<{
-  content: { type: "text"; text: string }[];
-  isError?: boolean;
-}>;
 
 // Flow Designer execution history. Each `sys_flow_context` row is one run of a
 // flow, subflow, or action; the step-by-step engine output for that run lives
@@ -132,7 +125,7 @@ export function registerFlowLogTools(
         .default(0)
         .describe("Result offset for pagination"),
     },
-    wrapHandler(
+    wrapHandler("search_flow_executions", 
       async (
         ctx: ToolContext,
         args: {
@@ -275,7 +268,7 @@ export function registerFlowLogTools(
         .default(200)
         .describe("Maximum log entries to return (oldest first)"),
     },
-    wrapHandler(
+    wrapHandler("get_flow_execution", 
       async (
         ctx: ToolContext,
         args: {

--- a/src/tools/formRules.ts
+++ b/src/tools/formRules.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import type { ToolContext } from "./registry.js";
+import type { ToolContext, WrapHandler } from "./registry.js";
 import { buildRecordUrl } from "./registry.js";
 import type {
   ServiceNowListResponse,
@@ -8,13 +8,6 @@ import type {
 } from "../servicenow/types.js";
 import { sanitizeValue } from "../servicenow/queryBuilder.js";
 import { validateSysId } from "../utils/validators.js";
-
-type WrapHandler = <T>(
-  handler: (ctx: ToolContext, args: T) => Promise<unknown>
-) => (args: T) => Promise<{
-  content: { type: "text"; text: string }[];
-  isError?: boolean;
-}>;
 
 // UI policies (sys_ui_policy) apply client-side field rules (mandatory / visible
 // / read-only / clear) when their `conditions` match. The per-field actions live
@@ -106,7 +99,7 @@ export function registerFormRulesTools(
         .default(0)
         .describe("Result offset for pagination"),
     },
-    wrapHandler(
+    wrapHandler("search_ui_policies", 
       async (
         ctx: ToolContext,
         args: {
@@ -172,7 +165,7 @@ export function registerFormRulesTools(
         .default(200)
         .describe("Maximum sys_ui_policy_action rows to return"),
     },
-    wrapHandler(
+    wrapHandler("get_ui_policy", 
       async (ctx: ToolContext, args: { sys_id: string; action_limit: number }) => {
         if (!validateSysId(args.sys_id)) {
           return {
@@ -267,7 +260,7 @@ export function registerFormRulesTools(
         .default(0)
         .describe("Result offset for pagination"),
     },
-    wrapHandler(
+    wrapHandler("search_client_scripts", 
       async (
         ctx: ToolContext,
         args: {
@@ -336,7 +329,7 @@ export function registerFormRulesTools(
     {
       sys_id: z.string().describe("Client script sys_id (32 hex chars)"),
     },
-    wrapHandler(async (ctx: ToolContext, args: { sys_id: string }) => {
+    wrapHandler("get_client_script", async (ctx: ToolContext, args: { sys_id: string }) => {
       if (!validateSysId(args.sys_id)) {
         return {
           success: false,
@@ -395,7 +388,7 @@ export function registerFormRulesTools(
         .default(0)
         .describe("Result offset for pagination"),
     },
-    wrapHandler(
+    wrapHandler("search_data_policies", 
       async (
         ctx: ToolContext,
         args: {
@@ -465,7 +458,7 @@ export function registerFormRulesTools(
         .default(200)
         .describe("Maximum sys_data_policy_rule rows to return"),
     },
-    wrapHandler(
+    wrapHandler("get_data_policy", 
       async (ctx: ToolContext, args: { sys_id: string; rule_limit: number }) => {
         if (!validateSysId(args.sys_id)) {
           return {

--- a/src/tools/incidents.ts
+++ b/src/tools/incidents.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import type { ToolContext } from "./registry.js";
+import type { ToolContext, WrapHandler } from "./registry.js";
 import { buildRecordUrl } from "./registry.js";
 import type {
   ServiceNowListResponse,
@@ -14,13 +14,6 @@ import {
   normalizeDateBoundary,
 } from "../utils/validators.js";
 import { sanitizeValue } from "../servicenow/queryBuilder.js";
-
-type WrapHandler = <T>(
-  handler: (ctx: ToolContext, args: T) => Promise<unknown>
-) => (args: T) => Promise<{
-  content: { type: "text"; text: string }[];
-  isError?: boolean;
-}>;
 
 export function registerIncidentTools(
   server: McpServer,
@@ -121,7 +114,7 @@ export function registerIncidentTools(
         .describe("Maximum results"),
       offset: z.number().int().min(0).default(0).describe("Result offset for pagination"),
     },
-    wrapHandler(
+    wrapHandler("search_incidents", 
       async (
         ctx: ToolContext,
         args: {
@@ -278,7 +271,7 @@ export function registerIncidentTools(
         .string()
         .describe("Incident number (e.g. INC0012345) or sys_id"),
     },
-    wrapHandler(async (ctx: ToolContext, args: { identifier: string }) => {
+    wrapHandler("get_incident", async (ctx: ToolContext, args: { identifier: string }) => {
       let path: string;
       let params: Record<string, string | number | boolean> = {};
 
@@ -345,7 +338,7 @@ export function registerIncidentTools(
       assignment_group: z.string().optional().describe("Assignment group name or sys_id"),
       cmdb_ci: z.string().optional().describe("Configuration item name or sys_id"),
     },
-    wrapHandler(
+    wrapHandler("create_incident", 
       async (
         ctx: ToolContext,
         args: {
@@ -401,7 +394,7 @@ export function registerIncidentTools(
           "Fields to update (e.g. { state: 'In Progress', assignment_group: 'Network' })"
         ),
     },
-    wrapHandler(
+    wrapHandler("update_incident", 
       async (
         ctx: ToolContext,
         args: { identifier: string; fields: Record<string, unknown> }
@@ -469,7 +462,7 @@ export function registerIncidentTools(
         .default("work_note")
         .describe("work_note = internal, comment = customer-visible"),
     },
-    wrapHandler(
+    wrapHandler("add_work_note", 
       async (
         ctx: ToolContext,
         args: { identifier: string; note: string; type: "work_note" | "comment" }

--- a/src/tools/knowledge.ts
+++ b/src/tools/knowledge.ts
@@ -1,15 +1,8 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import type { ToolContext } from "./registry.js";
+import type { ToolContext, WrapHandler } from "./registry.js";
 import { buildRecordUrl } from "./registry.js";
 import { validateSysId } from "../utils/validators.js";
-
-type WrapHandler = <T>(
-  handler: (ctx: ToolContext, args: T) => Promise<unknown>
-) => (args: T) => Promise<{
-  content: { type: "text"; text: string }[];
-  isError?: boolean;
-}>;
 
 export function registerKnowledgeTools(
   server: McpServer,
@@ -29,7 +22,7 @@ export function registerKnowledgeTools(
         .default(10)
         .describe("Maximum results"),
     },
-    wrapHandler(async (ctx: ToolContext, args: { query: string; limit: number }) => {
+    wrapHandler("search_knowledge", async (ctx: ToolContext, args: { query: string; limit: number }) => {
       const { data, headers } = await ctx.snClient.get<{ result: unknown[] }>(
         "/api/sn_km/knowledge/articles",
         {
@@ -63,7 +56,7 @@ export function registerKnowledgeTools(
     {
       sys_id: z.string().describe("Knowledge article sys_id"),
     },
-    wrapHandler(async (ctx: ToolContext, args: { sys_id: string }) => {
+    wrapHandler("get_article", async (ctx: ToolContext, args: { sys_id: string }) => {
       if (!validateSysId(args.sys_id)) {
         return {
           success: false,

--- a/src/tools/platformMetadata.ts
+++ b/src/tools/platformMetadata.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import type { ToolContext } from "./registry.js";
+import type { ToolContext, WrapHandler } from "./registry.js";
 import { buildRecordUrl } from "./registry.js";
 import type {
   ServiceNowListResponse,
@@ -8,13 +8,6 @@ import type {
 } from "../servicenow/types.js";
 import { sanitizeValue } from "../servicenow/queryBuilder.js";
 import { validateSysId } from "../utils/validators.js";
-
-type WrapHandler = <T>(
-  handler: (ctx: ToolContext, args: T) => Promise<unknown>
-) => (args: T) => Promise<{
-  content: { type: "text"; text: string }[];
-  isError?: boolean;
-}>;
 
 // Business rules live on sys_script. `collection` is the table the rule runs on,
 // `when` is the execution phase (before/after/async/display), and the logic is in
@@ -273,7 +266,7 @@ export function registerPlatformMetadataTools(
         .default(0)
         .describe("Result offset for pagination"),
     },
-    wrapHandler(
+    wrapHandler("search_business_rules", 
       async (
         ctx: ToolContext,
         args: {
@@ -355,7 +348,7 @@ export function registerPlatformMetadataTools(
     {
       sys_id: z.string().describe("Business rule sys_id (32 hex chars)"),
     },
-    wrapHandler(async (ctx: ToolContext, args: { sys_id: string }) => {
+    wrapHandler("get_business_rule", async (ctx: ToolContext, args: { sys_id: string }) => {
       if (!validateSysId(args.sys_id)) {
         return {
           success: false,
@@ -428,7 +421,7 @@ export function registerPlatformMetadataTools(
         .default(20)
         .describe("Maximum layouts to return when querying by `table`"),
     },
-    wrapHandler(
+    wrapHandler("get_list_view", 
       async (
         ctx: ToolContext,
         args: {
@@ -571,7 +564,7 @@ export function registerPlatformMetadataTools(
         .default(0)
         .describe("Result offset for pagination"),
     },
-    wrapHandler(
+    wrapHandler("search_navigator_modules", 
       async (
         ctx: ToolContext,
         args: {
@@ -651,7 +644,7 @@ export function registerPlatformMetadataTools(
         .default(0)
         .describe("Result offset for pagination"),
     },
-    wrapHandler(
+    wrapHandler("search_flow_definitions", 
       async (
         ctx: ToolContext,
         args: {
@@ -723,7 +716,7 @@ export function registerPlatformMetadataTools(
         .default(200)
         .describe("Maximum trigger/action instance rows to return per type"),
     },
-    wrapHandler(
+    wrapHandler("get_flow_definition", 
       async (
         ctx: ToolContext,
         args: {
@@ -815,7 +808,7 @@ export function registerPlatformMetadataTools(
         .default(200)
         .describe("Maximum sys_variable_value input rows to return"),
     },
-    wrapHandler(
+    wrapHandler("get_flow_action_inputs", 
       async (ctx: ToolContext, args: { sys_id: string; limit: number }) => {
         if (!validateSysId(args.sys_id)) {
           return {

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -7,6 +7,7 @@ import { TokenRefresher, AuthRequiredError } from "../auth/tokenRefresh.js";
 import { RateLimiter } from "../middleware/rateLimiter.js";
 import { ServiceNowClient } from "../servicenow/client.js";
 import { handleToolError, createToolError } from "../middleware/errorHandler.js";
+import type { UsageMetrics } from "../metrics/usage.js";
 import { logger } from "../utils/logger.js";
 import { registerUserTools } from "./users.js";
 import { registerIncidentTools } from "./incidents.js";
@@ -36,6 +37,14 @@ export interface ToolContext {
   displayName: string;
 }
 
+export type WrapHandler = <T>(
+  toolName: string,
+  handler: (ctx: ToolContext, args: T) => Promise<unknown>
+) => (
+  args: T,
+  extra?: { authInfo?: AuthInfo }
+) => Promise<{ content: { type: "text"; text: string }[]; isError?: boolean }>;
+
 export function buildRecordUrl(
   instanceUrl: string,
   table: string,
@@ -48,7 +57,8 @@ export function registerAllTools(
   server: McpServer,
   config: Config,
   redis: Redis,
-  tokenStore: TokenStore
+  tokenStore: TokenStore,
+  usageMetrics: UsageMetrics
 ): void {
   const refresher = new TokenRefresher(config, tokenStore, redis);
   const rateLimiter = new RateLimiter(redis, config.RATE_LIMIT_PER_USER);
@@ -89,21 +99,33 @@ export function registerAllTools(
   };
 
   // Wrapper that catches errors and returns consistent error responses
-  const wrapHandler = <T>(
+  const wrapHandler: WrapHandler = <T>(
+    toolName: string,
     handler: (ctx: ToolContext, args: T) => Promise<unknown>
   ) => {
     return async (args: T, extra?: { authInfo?: AuthInfo }) => {
+      // Duration covers the whole call, including auth/token resolution
+      const startTime = Date.now();
+      let ctx: ToolContext | undefined;
       try {
-        const ctx = await getContext(extra);
-        const startTime = Date.now();
+        ctx = await getContext(extra);
         const result = await handler(ctx, args);
         const duration = Date.now() - startTime;
         logger.info(
-          { userName: ctx.userName, duration },
+          { toolName, userName: ctx.userName, duration },
           "Tool call completed"
         );
+        usageMetrics.record(toolName, ctx.userName, true);
         return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
       } catch (err: unknown) {
+        const duration = Date.now() - startTime;
+        logger.warn(
+          { toolName, userName: ctx?.userName, duration },
+          "Tool call failed"
+        );
+        if (ctx) {
+          usageMetrics.record(toolName, ctx.userName, false);
+        }
         const toolErr = (err as { toolError?: unknown })?.toolError;
         if (toolErr) {
           return { content: [{ type: "text" as const, text: JSON.stringify(toolErr, null, 2) }], isError: true };

--- a/src/tools/scheduledJobs.ts
+++ b/src/tools/scheduledJobs.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import type { ToolContext } from "./registry.js";
+import type { ToolContext, WrapHandler } from "./registry.js";
 import { buildRecordUrl } from "./registry.js";
 import type {
   ServiceNowListResponse,
@@ -8,13 +8,6 @@ import type {
 } from "../servicenow/types.js";
 import { sanitizeValue } from "../servicenow/queryBuilder.js";
 import { validateSysId } from "../utils/validators.js";
-
-type WrapHandler = <T>(
-  handler: (ctx: ToolContext, args: T) => Promise<unknown>
-) => (args: T) => Promise<{
-  content: { type: "text"; text: string }[];
-  isError?: boolean;
-}>;
 
 // Parent `sysauto` table backs the "Scheduled Jobs" list and is extended by
 // every subclass: sysauto_script, sysauto_template (record generators),
@@ -104,7 +97,7 @@ export function registerScheduledJobTools(
         .default(0)
         .describe("Result offset for pagination"),
     },
-    wrapHandler(
+    wrapHandler("search_scheduled_jobs", 
       async (
         ctx: ToolContext,
         args: {
@@ -216,7 +209,7 @@ export function registerScheduledJobTools(
         .string()
         .describe("Scheduled job sys_id (32 hex chars)"),
     },
-    wrapHandler(
+    wrapHandler("get_scheduled_job", 
       async (ctx: ToolContext, args: { sys_id: string }) => {
         if (!validateSysId(args.sys_id)) {
           return {

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import type { ToolContext } from "./registry.js";
+import type { ToolContext, WrapHandler } from "./registry.js";
 import { buildRecordUrl } from "./registry.js";
 import type {
   ServiceNowListResponse,
@@ -10,13 +10,6 @@ import type {
 } from "../servicenow/types.js";
 import { validateSysId } from "../utils/validators.js";
 import { paginateAll } from "../servicenow/paginator.js";
-
-type WrapHandler = <T>(
-  handler: (ctx: ToolContext, args: T) => Promise<unknown>
-) => (args: T) => Promise<{
-  content: { type: "text"; text: string }[];
-  isError?: boolean;
-}>;
 
 export function registerTaskTools(
   server: McpServer,
@@ -29,7 +22,7 @@ export function registerTaskTools(
     {
       offset: z.number().int().min(0).default(0).describe("Starting offset for continuation when previous response was truncated"),
     },
-    wrapHandler(async (ctx: ToolContext, args: { offset: number }) => {
+    wrapHandler("get_my_tasks", async (ctx: ToolContext, args: { offset: number }) => {
       const { results, totalCount, truncated } = await paginateAll<Task>(
         async (limit, offset) => {
           const { data, headers } = await ctx.snClient.get<ServiceNowListResponse<Task>>(
@@ -75,7 +68,7 @@ export function registerTaskTools(
     {
       offset: z.number().int().min(0).default(0).describe("Starting offset for continuation when previous response was truncated"),
     },
-    wrapHandler(async (ctx: ToolContext, args: { offset: number }) => {
+    wrapHandler("get_my_approvals", async (ctx: ToolContext, args: { offset: number }) => {
       const { results, totalCount, truncated } = await paginateAll<Approval>(
         async (limit, offset) => {
           const { data, headers } = await ctx.snClient.get<ServiceNowListResponse<Approval>>(
@@ -123,7 +116,7 @@ export function registerTaskTools(
       action: z.enum(["approved", "rejected"]).describe("Approve or reject"),
       comments: z.string().optional().describe("Comments for the approval decision"),
     },
-    wrapHandler(
+    wrapHandler("approve_or_reject", 
       async (
         ctx: ToolContext,
         args: { sys_id: string; action: "approved" | "rejected"; comments?: string }

--- a/src/tools/updateSets.ts
+++ b/src/tools/updateSets.ts
@@ -1,16 +1,9 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import type { ToolContext } from "./registry.js";
+import type { ToolContext, WrapHandler } from "./registry.js";
 import { buildRecordUrl } from "./registry.js";
 import type { ServiceNowListResponse, ServiceNowSingleResponse } from "../servicenow/types.js";
 import { validateSysId } from "../utils/validators.js";
-
-type WrapHandler = <T>(
-  handler: (ctx: ToolContext, args: T) => Promise<unknown>
-) => (args: T) => Promise<{
-  content: { type: "text"; text: string }[];
-  isError?: boolean;
-}>;
 
 interface UpdateSetRecord {
   sys_id: string;
@@ -35,7 +28,7 @@ export function registerUpdateSetTools(
     "get_current_update_set",
     "Get the authenticated user's current ServiceNow update set.",
     {},
-    wrapHandler(async (ctx: ToolContext, _args: Record<string, never>) => {
+    wrapHandler("get_current_update_set", async (ctx: ToolContext, _args: Record<string, never>) => {
       const { data: preferenceData } = await ctx.snClient.get<
         ServiceNowListResponse<UserPreferenceRecord>
       >("/api/now/table/sys_user_preference", {
@@ -94,7 +87,7 @@ export function registerUpdateSetTools(
         .min(1)
         .describe("Update set sys_id or exact update set name"),
     },
-    wrapHandler(async (ctx: ToolContext, args: { identifier: string }) => {
+    wrapHandler("change_update_set", async (ctx: ToolContext, args: { identifier: string }) => {
       const isSysId = validateSysId(args.identifier);
       const encodedQuery = isSysId
         ? `sys_id=${args.identifier}^state=in progress`
@@ -194,7 +187,7 @@ export function registerUpdateSetTools(
         .default(true)
         .describe("Set this as the current update set (default: true)"),
     },
-    wrapHandler(
+    wrapHandler("create_update_set", 
       async (
         ctx: ToolContext,
         args: { name: string; description?: string; set_as_current: boolean }

--- a/src/tools/users.ts
+++ b/src/tools/users.ts
@@ -1,13 +1,9 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import type { ToolContext } from "./registry.js";
+import type { ToolContext, WrapHandler } from "./registry.js";
 import { buildRecordUrl } from "./registry.js";
 import type { ServiceNowListResponse, ServiceNowSingleResponse, User, Group } from "../servicenow/types.js";
 import { sanitizeValue } from "../servicenow/queryBuilder.js";
-
-type WrapHandler = <T>(
-  handler: (ctx: ToolContext, args: T) => Promise<unknown>
-) => (args: T) => Promise<{ content: { type: "text"; text: string }[]; isError?: boolean }>;
 
 export function registerUserTools(
   server: McpServer,
@@ -21,7 +17,7 @@ export function registerUserTools(
       query: z.string().describe("Search term: name, email, or employee ID"),
       limit: z.number().int().min(1).max(50).default(10).describe("Maximum results to return"),
     },
-    wrapHandler(async (ctx: ToolContext, args: { query: string; limit: number }) => {
+    wrapHandler("lookup_user", async (ctx: ToolContext, args: { query: string; limit: number }) => {
       const q = sanitizeValue(args.query);
 
       // Build OR query for name, email, employee_number
@@ -60,7 +56,7 @@ export function registerUserTools(
       query: z.string().describe("Group name to search for"),
       limit: z.number().int().min(1).max(50).default(10).describe("Maximum results to return"),
     },
-    wrapHandler(async (ctx: ToolContext, args: { query: string; limit: number }) => {
+    wrapHandler("lookup_group", async (ctx: ToolContext, args: { query: string; limit: number }) => {
       const { data, headers } = await ctx.snClient.get<ServiceNowListResponse<Group>>(
         "/api/now/table/sys_user_group",
         {
@@ -91,7 +87,7 @@ export function registerUserTools(
     "get_my_profile",
     "Get the authenticated user's own ServiceNow profile information.",
     {},
-    wrapHandler(async (ctx: ToolContext, _args: Record<string, never>) => {
+    wrapHandler("get_my_profile", async (ctx: ToolContext, _args: Record<string, never>) => {
       const { data } = await ctx.snClient.get<ServiceNowSingleResponse<User>>(
         `/api/now/table/sys_user/${ctx.userSysId}`,
         {

--- a/tests/unit/metrics/usage.test.ts
+++ b/tests/unit/metrics/usage.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MAX_SUMMARY_DAYS, UsageMetrics } from "../../../src/metrics/usage.js";
+
+vi.mock("../../../src/utils/logger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const FIXED_NOW = new Date("2026-07-17T12:00:00Z");
+const TODAY = "2026-07-17";
+const YESTERDAY = "2026-07-16";
+
+function flushAsync(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+describe("UsageMetrics.record", () => {
+  let chain: {
+    hincrby: ReturnType<typeof vi.fn>;
+    expire: ReturnType<typeof vi.fn>;
+    exec: ReturnType<typeof vi.fn>;
+  };
+  let metrics: UsageMetrics;
+
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(FIXED_NOW);
+
+    chain = {
+      hincrby: vi.fn(),
+      expire: vi.fn(),
+      exec: vi.fn().mockResolvedValue([]),
+    };
+    chain.hincrby.mockReturnValue(chain);
+    chain.expire.mockReturnValue(chain);
+    const redis = { multi: vi.fn(() => chain) };
+    metrics = new UsageMetrics(redis as never);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("increments the daily calls hash keyed by tool and user", () => {
+    metrics.record("lookup_user", "john.doe", true);
+
+    expect(chain.hincrby).toHaveBeenCalledWith(
+      `metrics:calls:${TODAY}`,
+      "lookup_user|john.doe",
+      1
+    );
+    expect(chain.expire).toHaveBeenCalledWith(
+      `metrics:calls:${TODAY}`,
+      400 * 86400,
+      "NX"
+    );
+    expect(chain.exec).toHaveBeenCalled();
+  });
+
+  it("uses the errors hash for failed calls", () => {
+    metrics.record("lookup_user", "john.doe", false);
+
+    expect(chain.hincrby).toHaveBeenCalledWith(
+      `metrics:errors:${TODAY}`,
+      "lookup_user|john.doe",
+      1
+    );
+  });
+
+  it("strips the field separator from tool and user names", () => {
+    metrics.record("weird|tool", "user|name", true);
+
+    expect(chain.hincrby).toHaveBeenCalledWith(
+      `metrics:calls:${TODAY}`,
+      "weird_tool|user_name",
+      1
+    );
+  });
+
+  it("swallows redis failures without throwing", async () => {
+    chain.exec.mockRejectedValue(new Error("redis down"));
+
+    expect(() => metrics.record("lookup_user", "john.doe", true)).not.toThrow();
+    await flushAsync();
+  });
+});
+
+describe("UsageMetrics.summary", () => {
+  let pipeline: {
+    hgetall: ReturnType<typeof vi.fn>;
+    exec: ReturnType<typeof vi.fn>;
+  };
+  let redis: { pipeline: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(FIXED_NOW);
+
+    pipeline = {
+      hgetall: vi.fn(),
+      exec: vi.fn(),
+    };
+    pipeline.hgetall.mockReturnValue(pipeline);
+    redis = { pipeline: vi.fn(() => pipeline) };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("aggregates calls and errors across days, tools, and users", async () => {
+    // days=2 → hgetall order: calls today, calls yesterday, errors today, errors yesterday
+    pipeline.exec.mockResolvedValue([
+      [null, { "lookup_user|john.doe": "3", "search_incidents|jane.roe": "2" }],
+      [null, { "lookup_user|john.doe": "5" }],
+      [null, { "lookup_user|john.doe": "1" }],
+      [null, {}],
+    ]);
+
+    const metrics = new UsageMetrics(redis as never);
+    const summary = await metrics.summary(2);
+
+    expect(pipeline.hgetall).toHaveBeenCalledWith(`metrics:calls:${TODAY}`);
+    expect(pipeline.hgetall).toHaveBeenCalledWith(`metrics:calls:${YESTERDAY}`);
+    expect(pipeline.hgetall).toHaveBeenCalledWith(`metrics:errors:${TODAY}`);
+    expect(pipeline.hgetall).toHaveBeenCalledWith(`metrics:errors:${YESTERDAY}`);
+
+    expect(summary.days).toBe(2);
+    expect(summary.from).toBe(YESTERDAY);
+    expect(summary.to).toBe(TODAY);
+    expect(summary.totals).toEqual({ calls: 10, errors: 1 });
+    expect(summary.byTool).toEqual({
+      lookup_user: { calls: 8, errors: 1 },
+      search_incidents: { calls: 2, errors: 0 },
+    });
+    expect(summary.byUser).toEqual({
+      "john.doe": { calls: 8, errors: 1 },
+      "jane.roe": { calls: 2, errors: 0 },
+    });
+    expect(summary.byDay).toEqual({
+      [TODAY]: { calls: 5, errors: 1 },
+      [YESTERDAY]: { calls: 5, errors: 0 },
+    });
+    expect(summary.byToolUser.lookup_user["john.doe"]).toEqual({
+      calls: 8,
+      errors: 1,
+    });
+  });
+
+  it("skips per-day results that errored and ignores malformed counts", async () => {
+    pipeline.exec.mockResolvedValue([
+      [new Error("failed"), null],
+      [null, { "lookup_user|john.doe": "not-a-number" }],
+    ]);
+
+    const metrics = new UsageMetrics(redis as never);
+    const summary = await metrics.summary(1);
+
+    expect(summary.totals).toEqual({ calls: 0, errors: 0 });
+    expect(summary.byTool).toEqual({});
+  });
+
+  it("caps the window at MAX_SUMMARY_DAYS and floors it at 1", async () => {
+    pipeline.exec.mockResolvedValue([]);
+    const metrics = new UsageMetrics(redis as never);
+
+    const capped = await metrics.summary(9999);
+    expect(capped.days).toBe(MAX_SUMMARY_DAYS);
+
+    const floored = await metrics.summary(-5);
+    expect(floored.days).toBe(1);
+  });
+});

--- a/tests/unit/server.test.ts
+++ b/tests/unit/server.test.ts
@@ -229,4 +229,73 @@ describe("createApp", () => {
     expect(transport.close).toHaveBeenCalledTimes(1);
     await request(app).get("/mcp").set("mcp-session-id", sessionId).expect(400);
   });
+
+  describe("GET /metrics/usage", () => {
+    const metricsToken = "metrics-secret-token-123";
+    const metricsConfig = { ...baseConfig, METRICS_TOKEN: metricsToken };
+
+    function redisWithUsageData() {
+      const pipeline = {
+        hgetall: vi.fn(),
+        exec: vi.fn().mockResolvedValue([
+          [null, { "lookup_user|john.doe": "3" }],
+          [null, { "lookup_user|john.doe": "1" }],
+        ]),
+      };
+      pipeline.hgetall.mockReturnValue(pipeline);
+      return {
+        ping: vi.fn().mockResolvedValue("PONG"),
+        pipeline: vi.fn(() => pipeline),
+      };
+    }
+
+    it("is not registered when METRICS_TOKEN is unset", async () => {
+      const redis = { ping: vi.fn().mockResolvedValue("PONG") };
+      const app = await createApp(baseConfig as any, redis as any);
+
+      await request(app).get("/metrics/usage").expect(404);
+    });
+
+    it("rejects requests without a valid bearer token", async () => {
+      const app = await createApp(metricsConfig as any, redisWithUsageData() as any);
+
+      await request(app).get("/metrics/usage").expect(401);
+      await request(app)
+        .get("/metrics/usage")
+        .set("Authorization", "Bearer wrong-token")
+        .expect(401);
+    });
+
+    it("returns the aggregated usage summary for a valid token", async () => {
+      const app = await createApp(metricsConfig as any, redisWithUsageData() as any);
+
+      const response = await request(app)
+        .get("/metrics/usage?days=1")
+        .set("Authorization", `Bearer ${metricsToken}`)
+        .expect(200);
+
+      expect(response.body.days).toBe(1);
+      expect(response.body.totals).toEqual({ calls: 3, errors: 1 });
+      expect(response.body.byTool.lookup_user).toEqual({ calls: 3, errors: 1 });
+      expect(response.body.byUser["john.doe"]).toEqual({ calls: 3, errors: 1 });
+    });
+
+    it("returns 500 when the summary query fails", async () => {
+      const pipeline = {
+        hgetall: vi.fn(),
+        exec: vi.fn().mockRejectedValue(new Error("redis down")),
+      };
+      pipeline.hgetall.mockReturnValue(pipeline);
+      const redis = {
+        ping: vi.fn().mockResolvedValue("PONG"),
+        pipeline: vi.fn(() => pipeline),
+      };
+      const app = await createApp(metricsConfig as any, redis as any);
+
+      await request(app)
+        .get("/metrics/usage")
+        .set("Authorization", `Bearer ${metricsToken}`)
+        .expect(500);
+    });
+  });
 });

--- a/tests/unit/tools/accessControl.test.ts
+++ b/tests/unit/tools/accessControl.test.ts
@@ -32,6 +32,7 @@ describe("registerAccessControlTools", () => {
     };
 
     const wrapHandler = <T>(
+      _toolName: string,
       handler: (context: ToolContext, args: T) => Promise<unknown>
     ) => {
       return async (args: T) => handler(ctx, args);

--- a/tests/unit/tools/catalog.test.ts
+++ b/tests/unit/tools/catalog.test.ts
@@ -37,6 +37,7 @@ describe("registerCatalogTools", () => {
     };
 
     const wrapHandler = <T>(
+      _toolName: string,
       handler: (context: ToolContext, args: T) => Promise<unknown>
     ) => {
       return async (args: T) => handler(ctx, args);

--- a/tests/unit/tools/catalogAdmin.test.ts
+++ b/tests/unit/tools/catalogAdmin.test.ts
@@ -39,6 +39,7 @@ describe("registerCatalogAdminTools", () => {
     };
 
     const wrapHandler = <T>(
+      _toolName: string,
       handler: (context: ToolContext, args: T) => Promise<unknown>
     ) => {
       return async (args: T) => handler(ctx, args);

--- a/tests/unit/tools/changeRequests.test.ts
+++ b/tests/unit/tools/changeRequests.test.ts
@@ -38,6 +38,7 @@ describe("registerChangeRequestTools", () => {
     };
 
     const wrapHandler = <T>(
+      _toolName: string,
       handler: (context: ToolContext, args: T) => Promise<unknown>
     ) => {
       return async (args: T) => handler(ctx, args);

--- a/tests/unit/tools/cmdb.test.ts
+++ b/tests/unit/tools/cmdb.test.ts
@@ -38,6 +38,7 @@ describe("registerCmdbTools", () => {
     };
 
     const wrapHandler = <T>(
+      _toolName: string,
       handler: (context: ToolContext, args: T) => Promise<unknown>
     ) => {
       return async (args: T) => handler(ctx, args);

--- a/tests/unit/tools/flowLogs.test.ts
+++ b/tests/unit/tools/flowLogs.test.ts
@@ -38,6 +38,7 @@ describe("registerFlowLogTools", () => {
     };
 
     const wrapHandler = <T>(
+      _toolName: string,
       handler: (context: ToolContext, args: T) => Promise<unknown>
     ) => {
       return async (args: T) => handler(ctx, args);

--- a/tests/unit/tools/formRules.test.ts
+++ b/tests/unit/tools/formRules.test.ts
@@ -32,6 +32,7 @@ describe("registerFormRulesTools", () => {
     };
 
     const wrapHandler = <T>(
+      _toolName: string,
       handler: (context: ToolContext, args: T) => Promise<unknown>
     ) => {
       return async (args: T) => handler(ctx, args);

--- a/tests/unit/tools/incidents.test.ts
+++ b/tests/unit/tools/incidents.test.ts
@@ -38,6 +38,7 @@ describe("registerIncidentTools", () => {
     };
 
     const wrapHandler = <T>(
+      _toolName: string,
       handler: (context: ToolContext, args: T) => Promise<unknown>
     ) => {
       return async (args: T) => handler(ctx, args);

--- a/tests/unit/tools/knowledge.test.ts
+++ b/tests/unit/tools/knowledge.test.ts
@@ -38,6 +38,7 @@ describe("registerKnowledgeTools", () => {
     };
 
     const wrapHandler = <T>(
+      _toolName: string,
       handler: (context: ToolContext, args: T) => Promise<unknown>
     ) => {
       return async (args: T) => handler(ctx, args);

--- a/tests/unit/tools/platformMetadata.test.ts
+++ b/tests/unit/tools/platformMetadata.test.ts
@@ -38,6 +38,7 @@ describe("registerPlatformMetadataTools", () => {
     };
 
     const wrapHandler = <T>(
+      _toolName: string,
       handler: (context: ToolContext, args: T) => Promise<unknown>
     ) => {
       return async (args: T) => handler(ctx, args);

--- a/tests/unit/tools/registry.test.ts
+++ b/tests/unit/tools/registry.test.ts
@@ -27,6 +27,8 @@ const mocks = vi.hoisted(() => ({
   createToolError: vi.fn(),
   handleToolError: vi.fn(),
   loggerInfo: vi.fn(),
+  loggerWarn: vi.fn(),
+  recordUsage: vi.fn(),
 }));
 
 vi.mock("../../../src/tools/users.js", () => ({
@@ -150,15 +152,19 @@ vi.mock("../../../src/middleware/errorHandler.js", () => ({
 vi.mock("../../../src/utils/logger.js", () => ({
   logger: {
     info: mocks.loggerInfo,
+    warn: mocks.loggerWarn,
+    debug: vi.fn(),
   },
 }));
 
 type WrapHandler = <T>(
+  toolName: string,
   handler: (ctx: ToolContext, args: T) => Promise<unknown>
 ) => (args: T, extra?: { authInfo?: { token: string; clientId: string; scopes: string[]; extra?: Record<string, unknown> } }) => Promise<{ content: { type: "text"; text: string }[]; isError?: boolean }>;
 
 describe("registerAllTools", () => {
   const tokenStore = {};
+  const usageMetrics = { record: mocks.recordUsage };
 
   const config = {
     RATE_LIMIT_PER_USER: 60,
@@ -230,16 +236,22 @@ describe("registerAllTools", () => {
       {} as any,
       config as any,
       {} as any,
-      tokenStore as any
+      tokenStore as any,
+      usageMetrics as any
     );
 
     const handler = vi.fn(async () => ({ success: true }));
-    const wrapped = capturedWrap(handler);
+    const wrapped = capturedWrap("test_tool", handler);
     const response = await wrapped({} as Record<string, never>);
 
     expect(handler).not.toHaveBeenCalled();
     expect(response.isError).toBe(true);
     expect(mocks.handleToolError).toHaveBeenCalled();
+    expect(mocks.recordUsage).not.toHaveBeenCalled();
+    expect(mocks.loggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ toolName: "test_tool" }),
+      "Tool call failed"
+    );
   });
 
   it("resolves user from authInfo when bearer auth is present", async () => {
@@ -247,11 +259,12 @@ describe("registerAllTools", () => {
       {} as any,
       config as any,
       {} as any,
-      tokenStore as any
+      tokenStore as any,
+      usageMetrics as any
     );
 
     const handler = vi.fn(async (_ctx: ToolContext) => ({ success: true }));
-    const wrapped = capturedWrap(handler);
+    const wrapped = capturedWrap("test_tool", handler);
 
     const extra = {
       authInfo: {
@@ -268,6 +281,15 @@ describe("registerAllTools", () => {
     expect(response.isError).toBeUndefined();
     const parsed = JSON.parse(response.content[0].text);
     expect(parsed.success).toBe(true);
+    expect(mocks.loggerInfo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolName: "test_tool",
+        userName: "john.doe",
+        duration: expect.any(Number),
+      }),
+      "Tool call completed"
+    );
+    expect(mocks.recordUsage).toHaveBeenCalledWith("test_tool", "john.doe", true);
   });
 
   it("passes through known toolError payloads from handlers", async () => {
@@ -275,7 +297,8 @@ describe("registerAllTools", () => {
       {} as any,
       config as any,
       {} as any,
-      tokenStore as any
+      tokenStore as any,
+      usageMetrics as any
     );
 
     const knownToolError = {
@@ -287,7 +310,7 @@ describe("registerAllTools", () => {
       },
     };
 
-    const wrapped = capturedWrap(async () => {
+    const wrapped = capturedWrap("test_tool", async () => {
       throw Object.assign(new Error("Validation failed"), {
         toolError: knownToolError,
       });
@@ -314,11 +337,12 @@ describe("registerAllTools", () => {
       {} as any,
       config as any,
       {} as any,
-      tokenStore as any
+      tokenStore as any,
+      usageMetrics as any
     );
 
     const boom = new Error("Boom");
-    const wrapped = capturedWrap(async () => {
+    const wrapped = capturedWrap("test_tool", async () => {
       throw boom;
     });
 
@@ -343,6 +367,11 @@ describe("registerAllTools", () => {
       },
     });
     expect(mocks.handleToolError).toHaveBeenCalledWith(boom);
+    expect(mocks.recordUsage).toHaveBeenCalledWith("test_tool", "john.doe", false);
+    expect(mocks.loggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ toolName: "test_tool", userName: "john.doe" }),
+      "Tool call failed"
+    );
   });
 });
 

--- a/tests/unit/tools/scheduledJobs.test.ts
+++ b/tests/unit/tools/scheduledJobs.test.ts
@@ -38,6 +38,7 @@ describe("registerScheduledJobTools", () => {
     };
 
     const wrapHandler = <T>(
+      _toolName: string,
       handler: (context: ToolContext, args: T) => Promise<unknown>
     ) => {
       return async (args: T) => handler(ctx, args);

--- a/tests/unit/tools/tasks.test.ts
+++ b/tests/unit/tools/tasks.test.ts
@@ -38,6 +38,7 @@ describe("registerTaskTools", () => {
     };
 
     const wrapHandler = <T>(
+      _toolName: string,
       handler: (context: ToolContext, args: T) => Promise<unknown>
     ) => {
       return async (args: T) => handler(ctx, args);

--- a/tests/unit/tools/updateSets.test.ts
+++ b/tests/unit/tools/updateSets.test.ts
@@ -38,6 +38,7 @@ describe("registerUpdateSetTools", () => {
     };
 
     const wrapHandler = <T>(
+      _toolName: string,
       handler: (context: ToolContext, args: T) => Promise<unknown>
     ) => {
       return async (args: T) => handler(ctx, args);

--- a/tests/unit/tools/users.test.ts
+++ b/tests/unit/tools/users.test.ts
@@ -38,6 +38,7 @@ describe("registerUserTools", () => {
     };
 
     const wrapHandler = <T>(
+      _toolName: string,
       handler: (context: ToolContext, args: T) => Promise<unknown>
     ) => {
       return async (args: T) => handler(ctx, args);


### PR DESCRIPTION
## Why

Container logs are wiped on every redeploy and the per-call log line never recorded which tool was invoked, so there was no way to measure who uses the server, which tools they use, or how often. This PR makes usage measurable and durable.

## What

- **Tool name in logs**: `wrapHandler` now takes the tool name as its first argument. Successful calls log `{ toolName, userName, duration }` ("Tool call completed"); failures now also log a "Tool call failed" line with the same shape. Duration now measures the whole call including auth/token resolution (previously handler-only).
- **Durable Redis counters**: new `UsageMetrics` records per-day hashes `metrics:calls:<YYYY-MM-DD>` / `metrics:errors:<YYYY-MM-DD>` with field `<toolName>|<userName>` and a 400-day TTL set on first increment (`EXPIRE NX`). Increments are fire-and-forget and can never fail or delay a tool call. Only calls that resolved an authenticated user context are counted.
- **Optional read endpoint**: `GET /metrics/usage?days=N` (clamped 1–400, default 30) returns totals plus byTool / byUser / byDay / byToolUser aggregates. Registered only when `METRICS_TOKEN` (min 16 chars) is configured; bearer token compared in constant time via hashed `timingSafeEqual`.
- **Type cleanup**: the 15 duplicated local `WrapHandler` type aliases in tool modules are replaced by one exported from `registry.ts`.

## Testing

- `npm run build` clean
- `npm test`: 432 tests / 38 files passing (11 new: UsageMetrics record/summary, endpoint auth + aggregation + failure paths, registry logging/metrics assertions)
- `npm run test:coverage` passing (98.1% statements overall)

🤖 Generated with [Claude Code](https://claude.com/claude-code)