### PR TITLE
Add permanent all-time usage counters alongside per-day metrics

### DIFF
--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -53,9 +53,17 @@ curl -s -H "Authorization: Bearer $METRICS_TOKEN" \
   "byTool": { "lookup_user": { "calls": 40, "errors": 1 } },
   "byUser": { "john.doe": { "calls": 80, "errors": 2 } },
   "byDay": { "2026-07-17": { "calls": 12, "errors": 0 } },
-  "byToolUser": { "lookup_user": { "john.doe": { "calls": 25, "errors": 1 } } }
+  "byToolUser": { "lookup_user": { "john.doe": { "calls": 25, "errors": 1 } } },
+  "allTime": {
+    "totals": { "calls": 900, "errors": 14 },
+    "byTool": { "lookup_user": { "calls": 300, "errors": 4 } },
+    "byUser": { "john.doe": { "calls": 610, "errors": 9 } },
+    "byToolUser": { "lookup_user": { "john.doe": { "calls": 210, "errors": 3 } } }
+  }
 }
 ```
+
+The windowed sections (`totals`, `byTool`, `byUser`, `byDay`, `byToolUser`) cover the requested `days` window and are limited by the 400-day per-day retention; `allTime` is cumulative since metrics were first deployed and never expires.
 
 **Response (401)** — missing or wrong bearer token. **Response (404)** — `METRICS_TOKEN` not configured.
 

--- a/docs/architecture/redis-schema.md
+++ b/docs/architecture/redis-schema.md
@@ -133,6 +133,17 @@ Per-day (UTC) tool-usage counters. Hash fields are `<toolName>|<userName>`; valu
 | **Set by** | `UsageMetrics.record()` (called from the tool `wrapHandler`) |
 | **Read by** | `UsageMetrics.summary()` (`GET /metrics/usage`) |
 
+### 11. `metrics:total:calls` / `metrics:total:errors` — All-Time Usage Counters
+
+Cumulative counters since metrics were first deployed. Same field layout as the per-day hashes but never expire — size is bounded by distinct tools × users, not by time, so growth is a few KB total.
+
+| Field | Value |
+|---|---|
+| **Type** | Hash (`<toolName>\|<userName>` → count) |
+| **TTL** | None (permanent) |
+| **Set by** | `UsageMetrics.record()` (same multi as the per-day increment) |
+| **Read by** | `UsageMetrics.summary()` — returned as the `allTime` section |
+
 ## Summary Table
 
 | Key Pattern | Type | TTL | Purpose |
@@ -148,6 +159,8 @@ Per-day (UTC) tool-usage counters. Hash fields are `<toolName>|<userName>`; valu
 | `mcp_refresh:<token>` | String (JSON) | 30 days | MCP refresh tokens |
 | `metrics:calls:<date>` | Hash | 400 days | Successful tool calls per tool/user/day |
 | `metrics:errors:<date>` | Hash | 400 days | Failed tool calls per tool/user/day |
+| `metrics:total:calls` | Hash | none | All-time successful tool calls per tool/user |
+| `metrics:total:errors` | Hash | none | All-time failed tool calls per tool/user |
 
 ---
 

--- a/src/metrics/usage.ts
+++ b/src/metrics/usage.ts
@@ -10,15 +10,20 @@ export interface UsageCounts {
   errors: number;
 }
 
-export interface UsageSummary {
-  days: number;
-  from: string;
-  to: string;
+export interface UsageAggregates {
   totals: UsageCounts;
   byTool: Record<string, UsageCounts>;
   byUser: Record<string, UsageCounts>;
-  byDay: Record<string, UsageCounts>;
   byToolUser: Record<string, Record<string, UsageCounts>>;
+}
+
+export interface UsageSummary extends UsageAggregates {
+  days: number;
+  from: string;
+  to: string;
+  byDay: Record<string, UsageCounts>;
+  /** Cumulative since metrics were first deployed; not limited by retention. */
+  allTime: UsageAggregates;
 }
 
 function utcDay(offsetDays = 0): string {
@@ -37,11 +42,14 @@ function emptyCounts(): UsageCounts {
 }
 
 /**
- * Durable per-day usage counters in Redis. Counters survive app redeploys
- * (unlike container logs) and expire after the retention window.
+ * Durable usage counters in Redis. Counters survive app redeploys (unlike
+ * container logs). Per-day hashes expire after the retention window; the
+ * all-time hashes never expire — their size is bounded by tools × users,
+ * not by time.
  *
- * Keys: metrics:calls:<YYYY-MM-DD> and metrics:errors:<YYYY-MM-DD> (UTC days),
- * hash fields "<toolName>|<userName>" holding call counts.
+ * Keys: metrics:calls:<YYYY-MM-DD> / metrics:errors:<YYYY-MM-DD> (UTC days)
+ * and metrics:total:calls / metrics:total:errors (no TTL), hash fields
+ * "<toolName>|<userName>" holding call counts.
  */
 export class UsageMetrics {
   constructor(
@@ -53,18 +61,24 @@ export class UsageMetrics {
     return `metrics:${kind}:${day}`;
   }
 
+  private totalKey(kind: "calls" | "errors"): string {
+    return `metrics:total:${kind}`;
+  }
+
   /**
    * Fire-and-forget increment; must never throw or delay a tool call.
    * Only calls that resolved a user context are recorded.
    */
   record(toolName: string, userName: string, ok: boolean): void {
     try {
-      const key = this.dayKey(ok ? "calls" : "errors", utcDay());
+      const kind = ok ? "calls" : "errors";
+      const key = this.dayKey(kind, utcDay());
       const field = `${sanitizeField(toolName)}|${sanitizeField(userName)}`;
       this.redis
         .multi()
         .hincrby(key, field, 1)
         .expire(key, this.retentionDays * DAY_SECONDS, "NX")
+        .hincrby(this.totalKey(kind), field, 1)
         .exec()
         .catch((err) => {
           logger.debug({ err }, "Usage metrics increment failed");
@@ -84,6 +98,8 @@ export class UsageMetrics {
     const pipeline = this.redis.pipeline();
     for (const day of dayList) pipeline.hgetall(this.dayKey("calls", day));
     for (const day of dayList) pipeline.hgetall(this.dayKey("errors", day));
+    pipeline.hgetall(this.totalKey("calls"));
+    pipeline.hgetall(this.totalKey("errors"));
     const results = (await pipeline.exec()) ?? [];
 
     const summary: UsageSummary = {
@@ -95,25 +111,34 @@ export class UsageMetrics {
       byUser: {},
       byDay: {},
       byToolUser: {},
+      allTime: {
+        totals: emptyCounts(),
+        byTool: {},
+        byUser: {},
+        byToolUser: {},
+      },
     };
 
     const ingest = (
-      day: string,
+      target: UsageAggregates,
       fields: Record<string, string>,
-      kind: keyof UsageCounts
+      kind: keyof UsageCounts,
+      day?: string
     ): void => {
       for (const [field, raw] of Object.entries(fields)) {
         const count = parseInt(raw, 10);
         if (!Number.isFinite(count)) continue;
         const [toolName, userName = "unknown"] = field.split("|");
 
-        summary.totals[kind] += count;
-        (summary.byTool[toolName] ??= emptyCounts())[kind] += count;
-        (summary.byUser[userName] ??= emptyCounts())[kind] += count;
-        (summary.byDay[day] ??= emptyCounts())[kind] += count;
-        ((summary.byToolUser[toolName] ??= {})[userName] ??= emptyCounts())[
+        target.totals[kind] += count;
+        (target.byTool[toolName] ??= emptyCounts())[kind] += count;
+        (target.byUser[userName] ??= emptyCounts())[kind] += count;
+        ((target.byToolUser[toolName] ??= {})[userName] ??= emptyCounts())[
           kind
         ] += count;
+        if (day !== undefined) {
+          (summary.byDay[day] ??= emptyCounts())[kind] += count;
+        }
       }
     };
 
@@ -121,11 +146,20 @@ export class UsageMetrics {
       const [callsErr, calls] = results[i] ?? [null, {}];
       const [errorsErr, errors] = results[dayList.length + i] ?? [null, {}];
       if (!callsErr && calls) {
-        ingest(dayList[i], calls as Record<string, string>, "calls");
+        ingest(summary, calls as Record<string, string>, "calls", dayList[i]);
       }
       if (!errorsErr && errors) {
-        ingest(dayList[i], errors as Record<string, string>, "errors");
+        ingest(summary, errors as Record<string, string>, "errors", dayList[i]);
       }
+    }
+
+    const [totalCallsErr, totalCalls] = results[dayList.length * 2] ?? [null, {}];
+    const [totalErrorsErr, totalErrors] = results[dayList.length * 2 + 1] ?? [null, {}];
+    if (!totalCallsErr && totalCalls) {
+      ingest(summary.allTime, totalCalls as Record<string, string>, "calls");
+    }
+    if (!totalErrorsErr && totalErrors) {
+      ingest(summary.allTime, totalErrors as Record<string, string>, "errors");
     }
 
     return summary;

--- a/tests/unit/metrics/usage.test.ts
+++ b/tests/unit/metrics/usage.test.ts
@@ -45,7 +45,7 @@ describe("UsageMetrics.record", () => {
     vi.useRealTimers();
   });
 
-  it("increments the daily calls hash keyed by tool and user", () => {
+  it("increments the daily and all-time calls hashes keyed by tool and user", () => {
     metrics.record("lookup_user", "john.doe", true);
 
     expect(chain.hincrby).toHaveBeenCalledWith(
@@ -58,14 +58,24 @@ describe("UsageMetrics.record", () => {
       400 * 86400,
       "NX"
     );
+    expect(chain.hincrby).toHaveBeenCalledWith(
+      "metrics:total:calls",
+      "lookup_user|john.doe",
+      1
+    );
     expect(chain.exec).toHaveBeenCalled();
   });
 
-  it("uses the errors hash for failed calls", () => {
+  it("uses the errors hashes for failed calls", () => {
     metrics.record("lookup_user", "john.doe", false);
 
     expect(chain.hincrby).toHaveBeenCalledWith(
       `metrics:errors:${TODAY}`,
+      "lookup_user|john.doe",
+      1
+    );
+    expect(chain.hincrby).toHaveBeenCalledWith(
+      "metrics:total:errors",
       "lookup_user|john.doe",
       1
     );
@@ -113,12 +123,15 @@ describe("UsageMetrics.summary", () => {
   });
 
   it("aggregates calls and errors across days, tools, and users", async () => {
-    // days=2 → hgetall order: calls today, calls yesterday, errors today, errors yesterday
+    // days=2 → hgetall order: calls today, calls yesterday, errors today,
+    // errors yesterday, then all-time calls and all-time errors
     pipeline.exec.mockResolvedValue([
       [null, { "lookup_user|john.doe": "3", "search_incidents|jane.roe": "2" }],
       [null, { "lookup_user|john.doe": "5" }],
       [null, { "lookup_user|john.doe": "1" }],
       [null, {}],
+      [null, { "lookup_user|john.doe": "40", "search_incidents|jane.roe": "7" }],
+      [null, { "lookup_user|john.doe": "2" }],
     ]);
 
     const metrics = new UsageMetrics(redis as never);
@@ -149,6 +162,14 @@ describe("UsageMetrics.summary", () => {
       calls: 8,
       errors: 1,
     });
+    expect(pipeline.hgetall).toHaveBeenCalledWith("metrics:total:calls");
+    expect(pipeline.hgetall).toHaveBeenCalledWith("metrics:total:errors");
+    expect(summary.allTime.totals).toEqual({ calls: 47, errors: 2 });
+    expect(summary.allTime.byTool).toEqual({
+      lookup_user: { calls: 40, errors: 2 },
+      search_incidents: { calls: 7, errors: 0 },
+    });
+    expect(summary.allTime.byUser["john.doe"]).toEqual({ calls: 40, errors: 2 });
   });
 
   it("skips per-day results that errored and ignores malformed counts", async () => {
@@ -162,6 +183,7 @@ describe("UsageMetrics.summary", () => {
 
     expect(summary.totals).toEqual({ calls: 0, errors: 0 });
     expect(summary.byTool).toEqual({});
+    expect(summary.allTime.totals).toEqual({ calls: 0, errors: 0 });
   });
 
   it("caps the window at MAX_SUMMARY_DAYS and floors it at 1", async () => {

--- a/tests/unit/server.test.ts
+++ b/tests/unit/server.test.ts
@@ -235,11 +235,14 @@ describe("createApp", () => {
     const metricsConfig = { ...baseConfig, METRICS_TOKEN: metricsToken };
 
     function redisWithUsageData() {
+      // days=1 → daily calls, daily errors, all-time calls, all-time errors
       const pipeline = {
         hgetall: vi.fn(),
         exec: vi.fn().mockResolvedValue([
           [null, { "lookup_user|john.doe": "3" }],
           [null, { "lookup_user|john.doe": "1" }],
+          [null, { "lookup_user|john.doe": "30" }],
+          [null, { "lookup_user|john.doe": "4" }],
         ]),
       };
       pipeline.hgetall.mockReturnValue(pipeline);
@@ -278,6 +281,8 @@ describe("createApp", () => {
       expect(response.body.totals).toEqual({ calls: 3, errors: 1 });
       expect(response.body.byTool.lookup_user).toEqual({ calls: 3, errors: 1 });
       expect(response.body.byUser["john.doe"]).toEqual({ calls: 3, errors: 1 });
+      expect(response.body.allTime.totals).toEqual({ calls: 30, errors: 4 });
+      expect(response.body.allTime.byTool.lookup_user).toEqual({ calls: 30, errors: 4 });
     });
 
     it("returns 500 when the summary query fails", async () => {


### PR DESCRIPTION
## Why

Per-day metrics hashes carry a 400-day TTL, so anything older than the retention window was lost — there was no "forever" view of usage.

## What

- `UsageMetrics.record()` now also increments `metrics:total:calls` / `metrics:total:errors` in the same `MULTI`. These hashes have **no TTL**; their size is bounded by distinct tools × users (a few KB total), not by time, so they can live forever without unbounded growth.
- `summary()` fetches both all-time hashes in the same pipeline and returns a new `allTime` section (`totals`, `byTool`, `byUser`, `byToolUser`) alongside the existing windowed view. Additive, non-breaking response change.
- Docs: redis-schema section + summary table rows for the new keys; endpoint example updated with `allTime` and a note on windowed vs cumulative semantics.

## Testing

- `npm run build` clean
- `npm test`: 432 tests / 38 files passing (record asserts both daily and all-time increments; summary asserts allTime aggregation and empty-state)
- `npm run test:coverage` passing (98.1% statements overall)

🤖 Generated with [Claude Code](https://claude.com/claude-code)